### PR TITLE
Unify edit-form actions and harden outbound/list/general config handling

### DIFF
--- a/frontend/src/pages/dns-rule-upsert-page.tsx
+++ b/frontend/src/pages/dns-rule-upsert-page.tsx
@@ -294,6 +294,7 @@ export function DnsRuleUpsertPage({
         <div className="flex justify-end gap-3">
           <Button
             onClick={() => navigate("/dns-rules")}
+            size="xl"
             type="button"
             variant="outline"
           >
@@ -301,6 +302,7 @@ export function DnsRuleUpsertPage({
           </Button>
           <Button
             disabled={postConfigMutation.isPending || !loadedConfig}
+            size="xl"
             type="submit"
           >
             {mode === "create" ? "Create rule" : "Save rule"}

--- a/frontend/src/pages/general-config-page.tsx
+++ b/frontend/src/pages/general-config-page.tsx
@@ -552,6 +552,10 @@ function buildUpdatedConfig(
   config: ConfigObject,
   draft: SettingsDraft
 ): ConfigObject {
+  const fwmarkStart = parseStrictHexToNumber(draft.fwmarkStart)
+  const fwmarkMask = parseStrictHexToNumber(draft.fwmarkMask)
+  const tableStart = parseStrictDecimalToNumber(draft.tableStart)
+
   return {
     ...config,
     daemon: {
@@ -560,12 +564,12 @@ function buildUpdatedConfig(
     },
     fwmark: {
       ...config.fwmark,
-      start: Number.parseInt(draft.fwmarkStart.slice(2), 16),
-      mask: Number.parseInt(draft.fwmarkMask.slice(2), 16),
+      start: toBackendIntegerValue(fwmarkStart, draft.fwmarkStart.trim()),
+      mask: toBackendIntegerValue(fwmarkMask, draft.fwmarkMask.trim()),
     },
     iproute: {
       ...config.iproute,
-      table_start: Number.parseInt(draft.tableStart, 10),
+      table_start: toBackendIntegerValue(tableStart, draft.tableStart.trim()),
     },
     lists_autoupdate: {
       ...config.lists_autoupdate,
@@ -590,6 +594,32 @@ function toStringInt(value: number | undefined, fallback: string) {
   }
 
   return String(value)
+}
+
+function parseStrictHexToNumber(value: string) {
+  const trimmed = value.trim()
+  if (!/^0x[0-9a-fA-F]+$/.test(trimmed)) {
+    return null
+  }
+
+  return Number.parseInt(trimmed.slice(2), 16)
+}
+
+function parseStrictDecimalToNumber(value: string) {
+  const trimmed = value.trim()
+  if (!/^\d+$/.test(trimmed)) {
+    return null
+  }
+
+  return Number.parseInt(trimmed, 10)
+}
+
+function toBackendIntegerValue(parsed: number | null, raw: string): number {
+  if (parsed !== null) {
+    return parsed
+  }
+
+  return raw as unknown as number
 }
 
 

--- a/frontend/src/pages/list-upsert-page.tsx
+++ b/frontend/src/pages/list-upsert-page.tsx
@@ -251,6 +251,7 @@ function ListForm({
                 <FieldContent>
                   <Input
                     aria-invalid={Boolean(error)}
+                    disabled={!isCreate}
                     id="list-name"
                     onBlur={field.handleBlur}
                     onChange={(event) => field.handleChange(event.target.value)}
@@ -475,42 +476,11 @@ function buildUpdatedConfigForListUpsert(
 ): ConfigObject {
   const nextLists = { ...(config.lists ?? {}) }
   const trimmedName = nextDraft.name.trim()
-  const trimmedOriginalName = originalName?.trim()
+  const resolvedName =
+    mode === "edit" ? (originalName?.trim() ?? trimmedName) : trimmedName
   const nextListConfig = getListConfigFromDraft(nextDraft)
 
-  if (
-    mode === "edit" &&
-    trimmedOriginalName &&
-    trimmedOriginalName !== trimmedName
-  ) {
-    delete nextLists[trimmedOriginalName]
-    nextLists[trimmedName] = nextListConfig
-
-    return {
-      ...config,
-      lists: nextLists,
-      route: {
-        ...config.route,
-        rules: (config.route?.rules ?? []).map((rule) => ({
-          ...rule,
-          list: rule.list.map((name) =>
-            name === trimmedOriginalName ? trimmedName : name
-          ),
-        })),
-      },
-      dns: {
-        ...config.dns,
-        rules: (config.dns?.rules ?? []).map((rule) => ({
-          ...rule,
-          list: rule.list.map((name) =>
-            name === trimmedOriginalName ? trimmedName : name
-          ),
-        })),
-      },
-    }
-  }
-
-  nextLists[trimmedName] = nextListConfig
+  nextLists[resolvedName] = nextListConfig
 
   return {
     ...config,

--- a/frontend/src/pages/outbound-upsert-page.tsx
+++ b/frontend/src/pages/outbound-upsert-page.tsx
@@ -322,9 +322,9 @@ function OutboundForm({
           <FieldContent>
             <Input
               defaultValue={draft.tag}
-              disabled={mode === "edit"}
               id={tagId}
               name="tag"
+              readOnly={mode === "edit"}
             />
             <FieldHint
               description="Use a unique outbound tag that can be referenced by rules, groups, and detours."

--- a/frontend/src/pages/routing-rule-upsert-page.tsx
+++ b/frontend/src/pages/routing-rule-upsert-page.tsx
@@ -441,6 +441,7 @@ export function RoutingRuleUpsertPage({
         <div className="flex justify-end gap-3">
           <Button
             onClick={() => navigate("/routing-rules")}
+            size="xl"
             type="button"
             variant="outline"
           >
@@ -456,6 +457,7 @@ export function RoutingRuleUpsertPage({
                 disabled={
                   postConfigMutation.isPending || !loadedConfig || !canSubmit
                 }
+                size="xl"
                 type="submit"
               >
                 {mode === "create" ? "Create rule" : "Save rule"}

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -22,6 +22,26 @@ void add_issue(std::vector<ConfigValidationIssue>& issues,
     issues.push_back({std::move(path), std::move(message)});
 }
 
+void validate_optional_integer_field(const json& root,
+                                     const char* parent_key,
+                                     const char* child_key,
+                                     const std::string& path,
+                                     std::vector<ConfigValidationIssue>& issues) {
+    const auto parent_it = root.find(parent_key);
+    if (parent_it == root.end() || !parent_it->is_object()) {
+        return;
+    }
+
+    const auto child_it = parent_it->find(child_key);
+    if (child_it == parent_it->end() || child_it->is_null()) {
+        return;
+    }
+
+    if (!child_it->is_number_integer()) {
+        add_issue(issues, path, path + " must be an integer");
+    }
+}
+
 } // namespace
 
 ConfigValidationError::ConfigValidationError(std::vector<ConfigValidationIssue> issues)
@@ -76,6 +96,7 @@ static void validate_fwmark_mask(uint32_t mask) {
 Config parse_config(const std::string& json_str) {
     Config cfg;
     json parsed_json;
+    std::vector<ConfigValidationIssue> issues;
 
     try {
         parsed_json = json::parse(json_str);
@@ -85,6 +106,17 @@ Config parse_config(const std::string& json_str) {
         });
     }
 
+    validate_optional_integer_field(
+        parsed_json, "fwmark", "start", "fwmark.start", issues);
+    validate_optional_integer_field(
+        parsed_json, "fwmark", "mask", "fwmark.mask", issues);
+    validate_optional_integer_field(
+        parsed_json, "iproute", "table_start", "iproute.table_start", issues);
+
+    if (!issues.empty()) {
+        throw ConfigValidationError(std::move(issues));
+    }
+
     try {
         cfg = parsed_json.get<Config>();
     } catch (const json::exception& e) {
@@ -92,8 +124,6 @@ Config parse_config(const std::string& json_str) {
             {"$", e.what()}
         });
     }
-
-    std::vector<ConfigValidationIssue> issues;
 
     if (cfg.lists_autoupdate) {
         const bool enabled = cfg.lists_autoupdate->enabled.value_or(false);

--- a/tests/test_config_validation.cpp
+++ b/tests/test_config_validation.cpp
@@ -276,6 +276,17 @@ TEST_CASE("iproute.table_start: value 32000 is rejected") {
     CHECK_THROWS_AS(parse_config(R"({"iproute":{"table_start":32000}})"), ConfigError);
 }
 
+TEST_CASE("iproute.table_start: non-integer value is rejected") {
+    CHECK_THROWS_AS(
+        parse_config(R"({"iproute":{"table_start":"400abc"}})"),
+        ConfigValidationError
+    );
+    CHECK_THROWS_AS(
+        parse_config(R"({"iproute":{"table_start":400.5}})"),
+        ConfigValidationError
+    );
+}
+
 // =============================================================================
 
 TEST_CASE("fwmark mask: invalid value is rejected during config parsing") {


### PR DESCRIPTION
## Summary
- standardize DNS rule and routing rule edit-form action buttons to use the same large button sizing as other upsert forms
- prevent list renames after creation by disabling the list name input in edit mode and always updating the original list key
- fix outbound edit regression where changing type could clear tag by keeping tag field submitted in edit mode (`readOnly` instead of `disabled`)
- tighten numeric handling for general settings so invalid values are sent to backend as invalid payloads rather than being silently truncated client-side
- add backend integer-type validation for `fwmark.start`, `fwmark.mask`, and `iproute.table_start`
- add config validation tests for non-integer `iproute.table_start` values

## Files changed
- `frontend/src/pages/routing-rule-upsert-page.tsx`
- `frontend/src/pages/dns-rule-upsert-page.tsx`
- `frontend/src/pages/list-upsert-page.tsx`
- `frontend/src/pages/outbound-upsert-page.tsx`
- `frontend/src/pages/general-config-page.tsx`
- `src/config/config.cpp`
- `tests/test_config_validation.cpp`

## Notes
- No runtime tests were executed in this environment (per task constraints).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf94e56890832abd104d9e2ee677fa)