### PR TITLE
Add resolver-config hash mismatch warnings with reload CTA and update health typing

### DIFF
--- a/frontend/src/api/generated/model/healthResponse.ts
+++ b/frontend/src/api/generated/model/healthResponse.ts
@@ -14,10 +14,10 @@ export interface HealthResponse {
   status: HealthResponseStatus;
   /** MD5 hex digest of the current domain-to-ipset mapping. Matches the txt-record written by generate-resolver-config; use to verify the dnsmasq config is up to date.
  */
-  resolver_config_hash?: string;
+  resolver_config_hash?: string | null;
   /** MD5 hex digest read from TXT record `config-hash.keen.pbr` using `dns.system_resolver.address`, normalized to a raw md5 string.
  */
-  resolver_config_hash_actual?: string;
+  resolver_config_hash_actual?: string | null;
   /** Whether a newer configuration has been staged in memory but not yet persisted and applied.
  */
   config_is_draft: boolean;

--- a/frontend/src/components/layout/warning-banner.tsx
+++ b/frontend/src/components/layout/warning-banner.tsx
@@ -1,5 +1,5 @@
 import { useGetHealthService, useGetConfig } from "@/api/queries"
-import { usePostConfigSaveMutation } from "@/api/mutations"
+import { usePostConfigSaveMutation, usePostReloadMutation } from "@/api/mutations"
 import { selectConfigIsDraft } from "@/api/selectors"
 import {
   Alert,
@@ -25,60 +25,102 @@ export function WarningBanner({
     },
   })
   const postConfigSaveMutation = usePostConfigSaveMutation()
+  const postReloadMutation = usePostReloadMutation()
 
+  const serviceHealth = healthQuery.data?.status === 200 ? healthQuery.data.data : null
   const isDraft =
-    healthQuery.data?.data.config_is_draft ?? selectConfigIsDraft(configQuery.data)
+    serviceHealth?.config_is_draft ?? selectConfigIsDraft(configQuery.data)
+  const expectedResolverHash = serviceHealth?.resolver_config_hash
+  const actualResolverHash = serviceHealth?.resolver_config_hash_actual
+  const hasResolverHashMismatch =
+    Boolean(expectedResolverHash) &&
+    Boolean(actualResolverHash) &&
+    expectedResolverHash !== actualResolverHash
 
-  if (!isDraft) {
+  if (!isDraft && !hasResolverHashMismatch) {
     return null
   }
 
   if (compact) {
     return (
-      <Alert
-        className={cn(
-          "mb-0 px-2 py-1.5 text-warning-foreground border-warning/50 bg-warning/5 [&_[data-slot=alert-title]]:text-xs [&_[data-slot=alert-title]]:font-medium",
-          className
-        )}
-      >
-        <AlertTitle>Configuration draft pending save.</AlertTitle>
-        <AlertAction className="top-1.5 right-1.5">
-          <Button
-            disabled={postConfigSaveMutation.isPending}
-            onClick={() => postConfigSaveMutation.mutate()}
-            size="xs"
-            variant="outline"
-          >
-            {postConfigSaveMutation.isPending ? "Saving..." : "Apply"}
-          </Button>
-        </AlertAction>
-      </Alert>
+      <div className={cn("space-y-2", className)}>
+        {isDraft ? (
+          <Alert className="mb-0 px-2 py-1.5 text-warning-foreground border-warning/50 bg-warning/5 [&_[data-slot=alert-title]]:text-xs [&_[data-slot=alert-title]]:font-medium">
+            <AlertTitle>Configuration draft pending save.</AlertTitle>
+            <AlertAction className="top-1.5 right-1.5">
+              <Button
+                disabled={postConfigSaveMutation.isPending}
+                onClick={() => postConfigSaveMutation.mutate()}
+                size="xs"
+                variant="outline"
+              >
+                {postConfigSaveMutation.isPending ? "Saving..." : "Apply"}
+              </Button>
+            </AlertAction>
+          </Alert>
+        ) : null}
+
+        {hasResolverHashMismatch ? (
+          <Alert className="mb-0 px-2 py-1.5 text-warning-foreground border-warning/50 bg-warning/5 [&_[data-slot=alert-title]]:text-xs [&_[data-slot=alert-title]]:font-medium">
+            <AlertTitle>dnsmasq config is stale; reload required.</AlertTitle>
+            <AlertAction className="top-1.5 right-1.5">
+              <Button
+                disabled={postReloadMutation.isPending}
+                onClick={() => postReloadMutation.mutate()}
+                size="xs"
+                variant="outline"
+              >
+                {postReloadMutation.isPending ? "Reloading..." : "Reload"}
+              </Button>
+            </AlertAction>
+          </Alert>
+        ) : null}
+      </div>
     )
   }
 
   return (
-    <Alert
-      className={cn(
-        "border-warning/50 bg-warning/5 text-warning-foreground",
-        "mb-6",
-        className
-      )}
-    >
-      <AlertTitle>Configuration is unsaved</AlertTitle>
-      <AlertDescription>
-        Configuration has been staged in memory. Save and apply it to persist it
-        to disk and reload the service.
-      </AlertDescription>
-      <AlertAction>
-        <Button
-          disabled={postConfigSaveMutation.isPending}
-          onClick={() => postConfigSaveMutation.mutate()}
-          size="sm"
-          variant="outline"
-        >
-          {postConfigSaveMutation.isPending ? "Applying..." : "Apply config"}
-        </Button>
-      </AlertAction>
-    </Alert>
+    <div className={cn("space-y-3", className)}>
+      {isDraft ? (
+        <Alert className="border-warning/50 bg-warning/5 text-warning-foreground">
+          <AlertTitle>Configuration is unsaved</AlertTitle>
+          <AlertDescription>
+            Configuration has been staged in memory. Save and apply it to persist it
+            to disk and reload the service.
+          </AlertDescription>
+          <AlertAction>
+            <Button
+              disabled={postConfigSaveMutation.isPending}
+              onClick={() => postConfigSaveMutation.mutate()}
+              size="sm"
+              variant="outline"
+            >
+              {postConfigSaveMutation.isPending ? "Applying..." : "Apply config"}
+            </Button>
+          </AlertAction>
+        </Alert>
+      ) : null}
+
+      {hasResolverHashMismatch ? (
+        <Alert className="border-warning/50 bg-warning/5 text-warning-foreground">
+          <AlertTitle>dnsmasq is using a stale resolver config</AlertTitle>
+          <AlertDescription>
+            The expected resolver hash ({expectedResolverHash?.slice(0, 10)}…)
+            doesn&apos;t match dnsmasq&apos;s active hash ({actualResolverHash?.slice(0, 10)}…).
+            Reload keen-pbr to regenerate and apply the current resolver configuration.
+          </AlertDescription>
+          <AlertAction>
+            <Button
+              disabled={postReloadMutation.isPending}
+              onClick={() => postReloadMutation.mutate()}
+              size="sm"
+              variant="outline"
+            >
+              {postReloadMutation.isPending ? "Reloading..." : "Reload service"}
+            </Button>
+          </AlertAction>
+        </Alert>
+      ) : null}
+    </div>
   )
 }

--- a/frontend/src/pages/overview-page.tsx
+++ b/frontend/src/pages/overview-page.tsx
@@ -61,6 +61,10 @@ export function OverviewPage() {
     routingHealthQuery.data?.status === 200
       ? routingHealthQuery.data.data
       : undefined
+  const hasResolverHashMismatch =
+    Boolean(serviceHealth?.resolver_config_hash) &&
+    Boolean(serviceHealth?.resolver_config_hash_actual) &&
+    serviceHealth?.resolver_config_hash !== serviceHealth?.resolver_config_hash_actual
 
   const outboundRows = useMemo(() => {
     if (!serviceHealth) {
@@ -133,7 +137,7 @@ export function OverviewPage() {
                   <div className="mb-1 text-sm text-muted-foreground">
                     Service status
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
                     <StatusBadge
                       tone={mapServiceStatusTone(serviceHealth.status)}
                     >
@@ -141,7 +145,17 @@ export function OverviewPage() {
                     </StatusBadge>
                     {serviceHealth.resolver_config_hash ? (
                       <Badge variant="outline" className="font-mono text-xs">
-                        {serviceHealth.resolver_config_hash.slice(0, 10)}…
+                        expected {serviceHealth.resolver_config_hash.slice(0, 10)}…
+                      </Badge>
+                    ) : null}
+                    {serviceHealth.resolver_config_hash_actual ? (
+                      <Badge variant="outline" className="font-mono text-xs">
+                        active {serviceHealth.resolver_config_hash_actual.slice(0, 10)}…
+                      </Badge>
+                    ) : null}
+                    {hasResolverHashMismatch ? (
+                      <Badge className="bg-warning/10 text-warning-foreground border-warning/50" variant="outline">
+                        dnsmasq stale
                       </Badge>
                     ) : null}
                   </div>


### PR DESCRIPTION
### Motivation
- Detect when dnsmasq is running a stale resolver config by comparing `resolver_config_hash` with `resolver_config_hash_actual` only when both are present. 
- Surface a distinct UI warning (separate from the draft-config warning) and provide a quick reload action so operators can bring dnsmasq back in sync. 
- Make frontend consumption of the health response robust when the backend may return `null` for hash fields.

### Description
- Compute `hasResolverHashMismatch` in `WarningBanner` and `OverviewPage` only when both `resolver_config_hash` and `resolver_config_hash_actual` exist and differ. (`frontend/src/components/layout/warning-banner.tsx`, `frontend/src/pages/overview-page.tsx`).
- `WarningBanner` now renders two independent notices: the existing draft-config warning and a new stale-dnsmasq warning; both compact and full variants include the mismatch notice and a reload CTA that calls the reload mutation. (`frontend/src/components/layout/warning-banner.tsx`).
- Updated the generated health model to allow nullable resolver hash fields: `resolver_config_hash?: string | null` and `resolver_config_hash_actual?: string | null`. (`frontend/src/api/generated/model/healthResponse.ts`).
- `OverviewPage` now displays the expected/active hash snippets and a `dnsmasq stale` badge when a mismatch is detected. (`frontend/src/pages/overview-page.tsx`).

### Testing
- Ran type check: `cd frontend && bun run typecheck` — succeeded. 
- Ran linter: `cd frontend && bun run lint` — failed in this environment due to a missing package (`@eslint/js`). 
- Ran build root `make` — failed in this environment due to missing system dependency `libnl-3.0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe55fa2f8832aa574e67d05eca8d1)