### PR TITLE
Run system resolver reload hook after daemon reload/apply operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(SOURCES
   src/dns/dns_router.cpp
   src/dns/dnsmasq_gen.cpp
   src/daemon/daemon.cpp
+  src/daemon/system_resolver_hook.cpp
   src/daemon/scheduler.cpp
   src/main.cpp
 )

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -34,6 +34,7 @@
 #include "../config/addr_spec.hpp"
 #include "../util/cron.hpp"
 #include "scheduler.hpp"
+#include "system_resolver_hook.hpp"
 
 #ifdef WITH_API
 #include "../api/handlers.hpp"
@@ -59,7 +60,10 @@ const Outbound* find_outbound(const std::vector<Outbound>& outbounds,
     return nullptr;
 }
 
-Daemon::Daemon(Config config, std::string config_path, DaemonOptions opts)
+Daemon::Daemon(Config config,
+               std::string config_path,
+               DaemonOptions opts,
+               HookCommandExecutor hook_command_executor)
     : config_(std::move(config))
     , config_path_(std::move(config_path))
     , opts_(std::move(opts))
@@ -72,7 +76,12 @@ Daemon::Daemon(Config config, std::string config_path, DaemonOptions opts)
     , url_tester_()
     , outbound_marks_(allocate_outbound_marks(config_.fwmark.value_or(FwmarkConfig{}),
                                              config_.outbounds.value_or(std::vector<Outbound>{})))
+    , hook_command_executor_(std::move(hook_command_executor))
 {
+    if (!hook_command_executor_) {
+        hook_command_executor_ = default_hook_command_executor;
+    }
+
     // Initialize epoll
     epoll_fd_ = epoll_create1(EPOLL_CLOEXEC);
     if (epoll_fd_ < 0) {
@@ -303,6 +312,31 @@ void Daemon::handle_sighup() {
     } catch (const std::exception& e) {
         log.error("SIGHUP: reload failed: {}", e.what());
     }
+}
+
+void Daemon::run_system_resolver_hook_reload() {
+    auto& log = Logger::instance();
+
+    std::string command;
+    int exit_code = 0;
+    const bool ok = execute_system_resolver_reload_hook(
+        config_,
+        hook_command_executor_,
+        command,
+        exit_code);
+
+    if (command.empty()) {
+        return;
+    }
+
+    if (!ok) {
+        log.warn("System resolver reload hook failed (exit code: {}): {}",
+                 exit_code,
+                 command);
+        return;
+    }
+
+    log.info("System resolver reload hook complete: {}", command);
 }
 
 void Daemon::add_fd(int fd, uint32_t events, FdCallback cb) {
@@ -831,6 +865,8 @@ void Daemon::apply_config(Config config) {
 
     // Recreate DNS test listener with the new config
     setup_dns_probe();
+
+    run_system_resolver_hook_reload();
 }
 
 

--- a/src/daemon/daemon.hpp
+++ b/src/daemon/daemon.hpp
@@ -22,6 +22,7 @@
 #include "../routing/netlink.hpp"
 #include "../routing/policy_rule.hpp"
 #include "../routing/route_table.hpp"
+#include "system_resolver_hook.hpp"
 
 namespace keen_pbr3 {
 
@@ -61,7 +62,10 @@ const Outbound* find_outbound(const std::vector<Outbound>& outbounds,
 // Handles signal dispatch, routing, firewall, urltest, and API lifecycle.
 class Daemon {
 public:
-    Daemon(Config config, std::string config_path, DaemonOptions opts);
+    Daemon(Config config,
+           std::string config_path,
+           DaemonOptions opts,
+           HookCommandExecutor hook_command_executor = default_hook_command_executor);
     ~Daemon();
 
     // Non-copyable, non-movable
@@ -113,6 +117,7 @@ private:
     void apply_config(Config config);
     void apply_config_with_rollback(const Config& next_config, bool& rolled_back);
     void reload_from_disk();
+    void run_system_resolver_hook_reload();
     void schedule_lists_autoupdate();
     void refresh_lists_and_maybe_reload();
 
@@ -191,6 +196,7 @@ private:
 #endif
 
     std::unique_ptr<class DnsProbeServer> dns_probe_server_;
+    HookCommandExecutor hook_command_executor_;
 };
 
 } // namespace keen_pbr3

--- a/src/daemon/system_resolver_hook.cpp
+++ b/src/daemon/system_resolver_hook.cpp
@@ -1,0 +1,49 @@
+#include "system_resolver_hook.hpp"
+
+#include <cstdlib>
+#include <sys/wait.h>
+
+namespace keen_pbr3 {
+
+std::string build_system_resolver_reload_command(const Config& config) {
+    if (!config.dns.has_value() || !config.dns->system_resolver.has_value()) {
+        return {};
+    }
+
+    const std::string& hook = config.dns->system_resolver->hook;
+    if (hook.empty()) {
+        return {};
+    }
+
+    return hook + " reload";
+}
+
+bool execute_system_resolver_reload_hook(
+    const Config& config,
+    const HookCommandExecutor& executor,
+    std::string& command,
+    int& exit_code) {
+    command = build_system_resolver_reload_command(config);
+    if (command.empty()) {
+        exit_code = 0;
+        return true;
+    }
+
+    exit_code = executor(command);
+    return exit_code == 0;
+}
+
+int default_hook_command_executor(const std::string& command) {
+    const int status = std::system(command.c_str());
+    if (status == -1) {
+        return -1;
+    }
+
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    }
+
+    return status;
+}
+
+} // namespace keen_pbr3

--- a/src/daemon/system_resolver_hook.hpp
+++ b/src/daemon/system_resolver_hook.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <functional>
+#include <string>
+
+#include "../config/config.hpp"
+
+namespace keen_pbr3 {
+
+using HookCommandExecutor = std::function<int(const std::string& command)>;
+
+std::string build_system_resolver_reload_command(const Config& config);
+
+bool execute_system_resolver_reload_hook(
+    const Config& config,
+    const HookCommandExecutor& executor,
+    std::string& command,
+    int& exit_code);
+
+int default_hook_command_executor(const std::string& command);
+
+} // namespace keen_pbr3

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(keen-pbr-tests
   test_list_set_usage.cpp
   test_config_validation.cpp
   test_routing_state.cpp
+  test_system_resolver_hook.cpp
   ../src/config/config.cpp
   ../src/config/routing_state.cpp
   ../src/firewall/iptables_verifier.cpp
@@ -24,6 +25,7 @@ add_executable(keen-pbr-tests
   ../src/dns/dnsmasq_gen.cpp
   ../src/dns/dns_router.cpp
   ../src/dns/dns_server.cpp
+  ../src/daemon/system_resolver_hook.cpp
   ../src/dns/dns_probe_server.cpp
   ../src/cache/cache_manager.cpp
   ../src/lists/list_streamer.cpp

--- a/tests/test_system_resolver_hook.cpp
+++ b/tests/test_system_resolver_hook.cpp
@@ -1,0 +1,68 @@
+#include "../src/daemon/system_resolver_hook.hpp"
+
+#include <doctest/doctest.h>
+
+namespace keen_pbr3 {
+
+TEST_CASE("build_system_resolver_reload_command: empty when resolver config absent") {
+    Config cfg;
+    CHECK(build_system_resolver_reload_command(cfg).empty());
+}
+
+TEST_CASE("build_system_resolver_reload_command: uses '<hook> reload'") {
+    Config cfg;
+    cfg.dns = DnsConfig{};
+    cfg.dns->system_resolver = api::SystemResolver{};
+    cfg.dns->system_resolver->hook = "/usr/local/bin/resolver-hook";
+
+    CHECK(build_system_resolver_reload_command(cfg) == "/usr/local/bin/resolver-hook reload");
+}
+
+TEST_CASE("execute_system_resolver_reload_hook: succeeds for zero exit code") {
+    Config cfg;
+    cfg.dns = DnsConfig{};
+    cfg.dns->system_resolver = api::SystemResolver{};
+    cfg.dns->system_resolver->hook = "resolver-hook";
+
+    std::string observed_command;
+    std::string command;
+    int exit_code = -1;
+
+    const bool ok = execute_system_resolver_reload_hook(
+        cfg,
+        [&observed_command](const std::string& cmd) {
+            observed_command = cmd;
+            return 0;
+        },
+        command,
+        exit_code);
+
+    CHECK(ok);
+    CHECK(command == "resolver-hook reload");
+    CHECK(observed_command == "resolver-hook reload");
+    CHECK(exit_code == 0);
+}
+
+TEST_CASE("execute_system_resolver_reload_hook: fails but remains non-throwing") {
+    Config cfg;
+    cfg.dns = DnsConfig{};
+    cfg.dns->system_resolver = api::SystemResolver{};
+    cfg.dns->system_resolver->hook = "resolver-hook";
+
+    std::string command;
+    int exit_code = -1;
+
+    const bool ok = execute_system_resolver_reload_hook(
+        cfg,
+        [](const std::string&) {
+            return 17;
+        },
+        command,
+        exit_code);
+
+    CHECK_FALSE(ok);
+    CHECK(command == "resolver-hook reload");
+    CHECK(exit_code == 17);
+}
+
+} // namespace keen_pbr3


### PR DESCRIPTION
### Motivation

- Ensure `dns.system_resolver.hook` is invoked with `<hook> reload` after any successful full reload/apply so external system resolver state stays in sync. 
- Make hook execution non-fatal and well-logged so daemon reload/apply visibility is preserved when the hook fails. 
- Execute the hook from the daemon control flow (serialized with the existing control-task queue) and make the command execution injectable for testability.

### Description

- Add a small helper abstraction in `src/daemon/system_resolver_hook.{hpp,cpp}` that builds the `<hook> reload` command from `config.dns.system_resolver.hook`, executes it via an injectable `HookCommandExecutor`, and provides `default_hook_command_executor` which uses `std::system` and interprets exit codes. 
- Extend `Daemon` to accept an optional `HookCommandExecutor` (defaulting to the system-backed executor), store it as `hook_command_executor_`, and add `run_system_resolver_hook_reload()` which runs the helper and logs success or non-fatal warnings on failure. 
- Invoke `run_system_resolver_hook_reload()` at the end of `apply_config()` so SIGHUP reloads, API-triggered reload/apply flows, and config-save apply paths all trigger the hook when a full apply completes. 
- Add unit tests `tests/test_system_resolver_hook.cpp` that validate command construction and executor behaviour using injected fake executors (no shelling out in tests). 
- Wire new source/test files into `CMakeLists.txt` and `tests/CMakeLists.txt` so the helper and tests are built with the project/test targets.

### Testing

- Attempted to build with `make` (root Makefile) which runs CMake and the build; CMake configure failed due to a missing pkg-config dependency `libnl-3.0`, so the build and test execution did not complete. 
- Added unit tests that exercise `build_system_resolver_reload_command()` and `execute_system_resolver_reload_hook()` with injected executors, but they were not executed here due to the configure/build failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff68c8d3c832a9f82d446c0ef69eb)