### PR TITLE
Serve SPA static frontend from API with register_static_root and packaging defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ add_link_options(-rdynamic)
 option(WITH_API "Build with REST API support (cpp-httplib)" ON)
 set(KEEN_PBR_DEFAULT_CONFIG_PATH "/etc/keen-pbr/config.json" CACHE STRING
   "Default config file path used by keen-pbr when --config is not passed")
+set(KEEN_PBR_FRONTEND_ROOT "/usr/share/keen-pbr/frontend" CACHE STRING
+  "Default frontend static root served by API (SPA assets)")
 
 # Dependencies
 find_package(CURL REQUIRED)
@@ -120,6 +122,7 @@ set_target_properties(keen-pbr PROPERTIES
 target_include_directories(keen-pbr PRIVATE include)
 target_compile_definitions(keen-pbr PRIVATE
   KEEN_PBR_DEFAULT_CONFIG_PATH="${KEEN_PBR_DEFAULT_CONFIG_PATH}"
+  KEEN_PBR_FRONTEND_ROOT="${KEEN_PBR_FRONTEND_ROOT}"
 )
 target_link_libraries(keen-pbr PRIVATE
   CURL::libcurl

--- a/packages/keenetic/keen-pbr/Makefile
+++ b/packages/keenetic/keen-pbr/Makefile
@@ -27,6 +27,7 @@ endef
 
 CMAKE_OPTIONS += \
 	-DKEEN_PBR_DEFAULT_CONFIG_PATH:STRING=/opt/etc/keen-pbr/config.json \
+	-DKEEN_PBR_FRONTEND_ROOT:STRING=/opt/usr/share/keen-pbr/frontend \
 	-DWITH_API=ON \
 	-DCMAKE_BUILD_TYPE=MinSizeRel
 

--- a/packages/openwrt/keen-pbr/Makefile
+++ b/packages/openwrt/keen-pbr/Makefile
@@ -27,6 +27,7 @@ endef
 
 CMAKE_OPTIONS += \
 	-DKEEN_PBR_DEFAULT_CONFIG_PATH:STRING=/etc/keen-pbr/config.json \
+	-DKEEN_PBR_FRONTEND_ROOT:STRING=/usr/share/keen-pbr/frontend \
 	-DWITH_API=ON \
 	-DCMAKE_BUILD_TYPE=MinSizeRel
 

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -5,8 +5,10 @@
 #include <cerrno>
 #include <chrono>
 #include <cstring>
+#include <filesystem>
 #include <httplib.h>
 #include <atomic>
+#include <cctype>
 #include <mutex>
 #include <nlohmann/json.hpp>
 
@@ -121,6 +123,60 @@ void ApiServer::get_stream(const std::string& path, StreamRouteHandler handler) 
             }
         }
     });
+}
+
+bool ApiServer::register_static_root(const std::string& frontend_root) {
+    namespace fs = std::filesystem;
+
+    const fs::path root(frontend_root);
+    const fs::path index_path = root / "index.html";
+    if (!fs::is_directory(root) || !fs::is_regular_file(index_path)) {
+        return false;
+    }
+
+    impl_->server.Get(R"(/(.*))", [root, index_path](const httplib::Request& req,
+                                                      httplib::Response& res) {
+        const bool is_api_route = req.path == "/api" || req.path.rfind("/api/", 0) == 0;
+        if (is_api_route) {
+            return;
+        }
+
+        std::string path_lower = req.path;
+        for (char& ch : path_lower) {
+            ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+        }
+
+        if (req.path.find("..") != std::string::npos ||
+            req.path.find('\\') != std::string::npos ||
+            path_lower.find("%2e%2e") != std::string::npos) {
+            res.status = 400;
+            res.set_content(make_error_json("invalid path"), "application/json");
+            return;
+        }
+
+        fs::path relative = req.path == "/" ? fs::path("index.html") : fs::path(req.path.substr(1));
+        if (relative.is_absolute()) {
+            res.status = 400;
+            res.set_content(make_error_json("invalid path"), "application/json");
+            return;
+        }
+
+        fs::path requested = root / relative;
+        if (fs::is_regular_file(requested)) {
+            if (!res.set_file_content(requested.string())) {
+                res.status = 404;
+            }
+            return;
+        }
+
+        if (!res.set_file_content(index_path.string())) {
+            res.status = 404;
+        } else {
+            res.status = 200;
+        }
+    });
+
+    return true;
 }
 
 void ApiServer::start() {

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -163,15 +163,14 @@ bool ApiServer::register_static_root(const std::string& frontend_root) {
 
         fs::path requested = root / relative;
         if (fs::is_regular_file(requested)) {
-            if (!res.set_file_content(requested.string())) {
-                res.status = 404;
-            }
+            res.set_file_content(requested.string());
             return;
         }
 
-        if (!res.set_file_content(index_path.string())) {
+        if (!fs::is_regular_file(index_path)) {
             res.status = 404;
         } else {
+            res.set_file_content(index_path.string());
             res.status = 200;
         }
     });

--- a/src/api/server.hpp
+++ b/src/api/server.hpp
@@ -76,6 +76,10 @@ public:
     // Register a GET handler that streams a non-JSON response.
     void get_stream(const std::string& path, StreamRouteHandler handler);
 
+    // Register static file serving and SPA fallback from frontend_root for non-/api routes.
+    // Returns false if static serving could not be configured.
+    bool register_static_root(const std::string& frontend_root);
+
     // Start listening in a background thread.
     void start();
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -36,6 +36,10 @@
 #include "scheduler.hpp"
 #include "system_resolver_hook.hpp"
 
+#ifndef KEEN_PBR_FRONTEND_ROOT
+#define KEEN_PBR_FRONTEND_ROOT "/usr/share/keen-pbr/frontend"
+#endif
+
 #ifdef WITH_API
 #include "../api/handlers.hpp"
 #include "../api/server.hpp"
@@ -912,6 +916,22 @@ void Daemon::setup_api() {
     if (!config_.api || !config_.api->enabled.value_or(false) || opts_.no_api) return;
 
     api_server_ = std::make_unique<ApiServer>(*config_.api);
+    const std::filesystem::path frontend_root(KEEN_PBR_FRONTEND_ROOT);
+    const std::filesystem::path frontend_index = frontend_root / "index.html";
+    const bool has_frontend_root =
+        std::filesystem::is_directory(frontend_root) &&
+        std::filesystem::is_regular_file(frontend_index);
+    if (!has_frontend_root) {
+        Logger::instance().warn(
+            "API enabled but frontend root is unavailable: {} (missing directory or index.html). API endpoints will remain available.",
+            frontend_root.string());
+    } else if (!api_server_->register_static_root(frontend_root.string())) {
+        Logger::instance().warn(
+            "Failed to register frontend static root: {}. API endpoints will remain available.",
+            frontend_root.string());
+    } else {
+        Logger::instance().info("Frontend static root: {}", frontend_root.string());
+    }
 
     // ApiContext provides synchronized access to Daemon-owned runtime state.
     api_ctx_ = std::make_unique<ApiContext>(ApiContext{


### PR DESCRIPTION
### Motivation

- Provide an option to serve a single-page application (SPA) frontend from the API process so routers can ship static assets together with the daemon.
- Allow packaging to supply a platform-appropriate default frontend root path and make it available to the daemon at compile time.
- Ensure static serving is secure and falls back to the SPA `index.html` for client-side routes while leaving `/api` routes unaffected.

### Description

- Add `KEEN_PBR_FRONTEND_ROOT` CMake cache variable and inject it into `keen-pbr` via `target_compile_definitions` so builds can embed a default frontend path.
- Introduce `ApiServer::register_static_root(const std::string&)` (declaration in `src/api/server.hpp`) and implement it in `src/api/server.cpp` using `std::filesystem` to serve files and provide SPA fallback to `index.html` for non-API routes, with path traversal and encoding checks.
- Update `src/daemon/daemon.cpp` to define a default `KEEN_PBR_FRONTEND_ROOT` when not provided, detect presence of the frontend root and `index.html`, register the static root on the API server, and log warnings or info accordingly.
- Update packaging `Makefile`s for `keenetic` and `openwrt` to pass distribution-specific `KEEN_PBR_FRONTEND_ROOT` values via `CMAKE_OPTIONS`.
- Add required includes (`<filesystem>`, `<cctype>`) and minor compile/link adjustments in the build files.

### Testing

- No existing automated unit tests were modified for this change.
- Verified project configuration and build with `-DWITH_API=ON -DCMAKE_BUILD_TYPE=MinSizeRel` by running `cmake -S . -B build -DWITH_API=ON -DCMAKE_BUILD_TYPE=MinSizeRel` and `cmake --build build`, and the build completed successfully.
- Packaging Makefile changes were added to existing package build flows but no package integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c01c498784832ab40aa7786a8e7bf2)