### PR TITLE
Add Vite gzip precompression for production assets

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -39,6 +39,7 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
         "vite": "^7.2.4",
+        "vite-plugin-compression": "^0.5.1",
       },
     },
   },
@@ -1219,6 +1220,8 @@
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
+    "vite-plugin-compression": ["vite-plugin-compression@0.5.1", "", { "dependencies": { "chalk": "^4.1.2", "debug": "^4.3.3", "fs-extra": "^10.0.0" }, "peerDependencies": { "vite": ">=2.0.0" } }, "sha512-5QJKBDc+gNYVqL/skgFAP81Yuzo9R+EAf19d+EtsMF/i8kFUpNi3J/H01QD3Oo8zBQn+NzoCIFkpPLynoOzaJg=="],
+
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -1342,6 +1345,8 @@
     "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "typedoc/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "vite-plugin-compression/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,7 @@
     "prettier-plugin-tailwindcss": "^0.7.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vite-plugin-compression": "^0.5.1"
   }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,11 +1,29 @@
 import path from "path"
 import tailwindcss from "@tailwindcss/vite"
 import react from "@vitejs/plugin-react"
+import viteCompression from "vite-plugin-compression"
+import { constants } from "zlib"
 import { defineConfig } from "vite"
 
+const textAssetPattern = /\.(html?|css|js|mjs|cjs|jsx|ts|tsx|json|svg|txt|xml|wasm|map)$/i
+
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
+export default defineConfig(({ mode }) => ({
+  plugins: [
+    react(),
+    tailwindcss(),
+    viteCompression({
+      algorithm: "gzip",
+      ext: ".gz",
+      threshold: 0,
+      filter: textAssetPattern,
+      deleteOriginFile: false,
+      disable: mode === "development",
+      compressionOptions: {
+        level: constants.Z_BEST_COMPRESSION,
+      },
+    }),
+  ],
   server: {
     proxy: {
       "/api": {
@@ -19,4 +37,4 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-})
+}))


### PR DESCRIPTION
### Motivation
- Improve production delivery performance by emitting precompressed gzip assets at build time for common text formats (`html/js/css/svg/json/...`).
- Preserve original files for fallback tooling and servers that do not serve precompressed files by keeping both compressed and uncompressed outputs.
- Make CI/release builds deterministic by fixing gzip compression parameters so artifacts are reproducible across environments.

### Description
- Add `vite-plugin-compression` to the frontend dev dependencies and update lock metadata via `bun` to enable build-time compression. 
- Update `frontend/vite.config.ts` to register the plugin with `algorithm: "gzip"`, `ext: ".gz"`, `filter` matching text assets, `threshold: 0`, and `deleteOriginFile: false`, and to disable the plugin in development using `disable: mode === "development"`.
- Set a fixed compression level using `compressionOptions.level = constants.Z_BEST_COMPRESSION` to enforce deterministic output in CI/release builds.

### Testing
- Ran `bun run build` in `frontend/` which completed successfully and produced `.gz` artifacts alongside original files. ✅
- Fixed a TypeScript typing issue by removing the unsupported `mtime` option and re-running the build sequence (`tsc -b && vite build`) which succeeded after the fix. ✅
- Running top-level `make` failed in this environment due to a missing system package (`libnl-3.0`) required by CMake, which is unrelated to the frontend change. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02330af00832aa6760bb6c7d58915)