### PR TITLE
Package frontend assets for keen-pbr: run bun build and install dist files

### DIFF
--- a/.github/workflows/build-keenetic-packages.yml
+++ b/.github/workflows/build-keenetic-packages.yml
@@ -6,9 +6,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  prepare-frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build frontend
+        run: bun run build
+      - name: Keep only .gz frontend assets
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/frontend-dist-gz"
+          cd dist
+          find . -type f -name '*.gz' -exec cp --parents {} "$GITHUB_WORKSPACE/frontend-dist-gz" \;
+      - name: Upload frontend bundle
+        uses: actions/upload-artifact@v6
+        with:
+          name: frontend-dist-gz
+          path: frontend-dist-gz
+
   build:
     name: "mipsel-3.4"
     runs-on: ubuntu-latest
+    needs: prepare-frontend
     container:
       image: ghcr.io/maksimkurb/entware-builder:mipsel-3.4
       options: --user root
@@ -16,6 +40,16 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
+      - name: Download frontend bundle
+        uses: actions/download-artifact@v6
+        with:
+          name: frontend-dist-gz
+          path: frontend-dist-gz
+      - name: Stage frontend dist
+        run: |
+          rm -rf "$GITHUB_WORKSPACE/frontend/dist"
+          mkdir -p "$GITHUB_WORKSPACE/frontend/dist"
+          cp -a "$GITHUB_WORKSPACE/frontend-dist-gz"/. "$GITHUB_WORKSPACE/frontend/dist/"
       - name: Build package
         working-directory: /home/me/Entware
         run: |

--- a/.github/workflows/build-openwrt-packages.yml
+++ b/.github/workflows/build-openwrt-packages.yml
@@ -11,14 +11,51 @@ on:
         default: '24.10.4'
 
 jobs:
-  build:
-    name: "mediatek/filogic"
+  prepare-frontend:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/frontend
     steps:
       - uses: actions/checkout@v5
         with:
           path: src
           submodules: recursive
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build frontend
+        run: bun run build
+      - name: Keep only .gz frontend assets
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/frontend-dist-gz"
+          cd dist
+          find . -type f -name '*.gz' -exec cp --parents {} "$GITHUB_WORKSPACE/frontend-dist-gz" \;
+      - name: Upload frontend bundle
+        uses: actions/upload-artifact@v6
+        with:
+          name: frontend-dist-gz
+          path: frontend-dist-gz
+
+  build:
+    name: "mediatek/filogic"
+    runs-on: ubuntu-latest
+    needs: prepare-frontend
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: src
+          submodules: recursive
+      - name: Download frontend bundle
+        uses: actions/download-artifact@v6
+        with:
+          name: frontend-dist-gz
+          path: frontend-dist-gz
+      - name: Stage frontend dist
+        run: |
+          rm -rf "$GITHUB_WORKSPACE/src/frontend/dist"
+          mkdir -p "$GITHUB_WORKSPACE/src/frontend/dist"
+          cp -a "$GITHUB_WORKSPACE/frontend-dist-gz"/. "$GITHUB_WORKSPACE/src/frontend/dist/"
       - name: Cache SDK
         id: cache
         uses: actions/cache@v4

--- a/.github/workflows/release-keenetic-packages.yml
+++ b/.github/workflows/release-keenetic-packages.yml
@@ -10,6 +10,29 @@ on:
         required: false
 
 jobs:
+  prepare-frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build frontend
+        run: bun run build
+      - name: Keep only .gz frontend assets
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/frontend-dist-gz"
+          cd dist
+          find . -type f -name '*.gz' -exec cp --parents {} "$GITHUB_WORKSPACE/frontend-dist-gz" \;
+      - name: Upload frontend bundle
+        uses: actions/upload-artifact@v6
+        with:
+          name: frontend-dist-gz
+          path: frontend-dist-gz
+
   generate-config:
     runs-on: ubuntu-latest
     outputs:
@@ -51,7 +74,7 @@ jobs:
   build:
     name: "${{ matrix.build_env.config_name }}"
     runs-on: ubuntu-latest
-    needs: generate-config
+    needs: [generate-config, prepare-frontend]
     strategy:
       fail-fast: false
       matrix:
@@ -63,6 +86,16 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
+      - name: Download frontend bundle
+        uses: actions/download-artifact@v6
+        with:
+          name: frontend-dist-gz
+          path: frontend-dist-gz
+      - name: Stage frontend dist
+        run: |
+          rm -rf "$GITHUB_WORKSPACE/frontend/dist"
+          mkdir -p "$GITHUB_WORKSPACE/frontend/dist"
+          cp -a "$GITHUB_WORKSPACE/frontend-dist-gz"/. "$GITHUB_WORKSPACE/frontend/dist/"
       - name: Build package
         working-directory: /home/me/Entware
         run: |

--- a/.github/workflows/release-openwrt-packages.yml
+++ b/.github/workflows/release-openwrt-packages.yml
@@ -17,6 +17,32 @@ on:
         required: false
 
 jobs:
+  prepare-frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/frontend
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: src
+          submodules: recursive
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build frontend
+        run: bun run build
+      - name: Keep only .gz frontend assets
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/frontend-dist-gz"
+          cd dist
+          find . -type f -name '*.gz' -exec cp --parents {} "$GITHUB_WORKSPACE/frontend-dist-gz" \;
+      - name: Upload frontend bundle
+        uses: actions/upload-artifact@v6
+        with:
+          name: frontend-dist-gz
+          path: frontend-dist-gz
+
   generate-config:
     runs-on: ubuntu-latest
     outputs:
@@ -38,7 +64,7 @@ jobs:
   build:
     name: "${{ matrix.build_env.target }}/${{ matrix.build_env.subtarget }} (${{ matrix.build_env.pkgarch }})"
     runs-on: ubuntu-latest
-    needs: generate-config
+    needs: [generate-config, prepare-frontend]
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +74,16 @@ jobs:
         with:
           path: src
           submodules: recursive
+      - name: Download frontend bundle
+        uses: actions/download-artifact@v6
+        with:
+          name: frontend-dist-gz
+          path: frontend-dist-gz
+      - name: Stage frontend dist
+        run: |
+          rm -rf "$GITHUB_WORKSPACE/src/frontend/dist"
+          mkdir -p "$GITHUB_WORKSPACE/src/frontend/dist"
+          cp -a "$GITHUB_WORKSPACE/frontend-dist-gz"/. "$GITHUB_WORKSPACE/src/frontend/dist/"
       - name: Cache SDK
         id: cache
         uses: actions/cache@v4

--- a/packages/keenetic/keen-pbr/Makefile
+++ b/packages/keenetic/keen-pbr/Makefile
@@ -55,7 +55,7 @@ define Package/keen-pbr/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/keenetic/keen-pbr/files/opt/etc/ndm/iflayerchanged.d/50-keen-pbr-routing.sh $(1)/opt/etc/ndm/iflayerchanged.d/50-keen-pbr-routing.sh
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/keenetic/keen-pbr/files/opt/etc/ndm/ifstatechanged.d/50-keen-pbr-routing.sh $(1)/opt/etc/ndm/ifstatechanged.d/50-keen-pbr-routing.sh
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/keenetic/keen-pbr/files/opt/etc/ndm/netfilter.d/50-keen-pbr-routing.sh $(1)/opt/etc/ndm/netfilter.d/50-keen-pbr-routing.sh
-	(cd $(PKG_BUILD_DIR)/frontend/dist && find . -type f -name '*.gz' -exec cp --parents {} $(1)/opt/usr/share/keen-pbr/frontend/ \;)
+	$(CP) $(PKG_BUILD_DIR)/frontend/dist/. $(1)/opt/usr/share/keen-pbr/frontend/
 	chmod -R a=rX,u+w $(1)/opt/usr/share/keen-pbr/frontend
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/config.example.json $(1)/opt/etc/keen-pbr/config.json
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/packages/common/local.lst $(1)/opt/etc/keen-pbr/local.lst

--- a/packages/keenetic/keen-pbr/Makefile
+++ b/packages/keenetic/keen-pbr/Makefile
@@ -23,11 +23,7 @@ KEEN_PBR_SRC ?= /home/me/keen-pbr-src
 define Build/Prepare
 	mkdir -p $(PKG_BUILD_DIR)
 	cp -a $(KEEN_PBR_SRC)/. $(PKG_BUILD_DIR)/
-endef
-
-define Build/Compile
-	(cd $(PKG_BUILD_DIR)/frontend && bun install --frozen-lockfile && bun run build)
-	$(call Build/Compile/Default)
+	@test -d $(PKG_BUILD_DIR)/frontend/dist || (echo "Missing frontend/dist (provide frontend-build artifacts in KEEN_PBR_SRC)"; false)
 endef
 
 CMAKE_OPTIONS += \

--- a/packages/keenetic/keen-pbr/Makefile
+++ b/packages/keenetic/keen-pbr/Makefile
@@ -25,6 +25,11 @@ define Build/Prepare
 	cp -a $(KEEN_PBR_SRC)/. $(PKG_BUILD_DIR)/
 endef
 
+define Build/Compile
+	(cd $(PKG_BUILD_DIR)/frontend && bun install --frozen-lockfile && bun run build)
+	$(call Build/Compile/Default)
+endef
+
 CMAKE_OPTIONS += \
 	-DKEEN_PBR_DEFAULT_CONFIG_PATH:STRING=/opt/etc/keen-pbr/config.json \
 	-DKEEN_PBR_FRONTEND_ROOT:STRING=/opt/usr/share/keen-pbr/frontend \
@@ -44,6 +49,7 @@ define Package/keen-pbr/install
 	$(INSTALL_DIR) $(1)/opt/etc/ndm/ifstatechanged.d
 	$(INSTALL_DIR) $(1)/opt/etc/ndm/netfilter.d
 	$(INSTALL_DIR) $(1)/opt/usr/bin
+	$(INSTALL_DIR) $(1)/opt/usr/share/keen-pbr/frontend
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/opt/bin/keen-pbr $(1)/opt/usr/bin/keen-pbr
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/keenetic/keen-pbr/files/opt/etc/init.d/S80keen-pbr $(1)/opt/etc/init.d/S80keen-pbr
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/packages/keenetic/keen-pbr/files/opt/etc/dnsmasq.d/dnsmasq.keen-pbr.conf $(1)/opt/etc/dnsmasq.d/dnsmasq.keen-pbr.conf
@@ -53,6 +59,8 @@ define Package/keen-pbr/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/keenetic/keen-pbr/files/opt/etc/ndm/iflayerchanged.d/50-keen-pbr-routing.sh $(1)/opt/etc/ndm/iflayerchanged.d/50-keen-pbr-routing.sh
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/keenetic/keen-pbr/files/opt/etc/ndm/ifstatechanged.d/50-keen-pbr-routing.sh $(1)/opt/etc/ndm/ifstatechanged.d/50-keen-pbr-routing.sh
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/keenetic/keen-pbr/files/opt/etc/ndm/netfilter.d/50-keen-pbr-routing.sh $(1)/opt/etc/ndm/netfilter.d/50-keen-pbr-routing.sh
+	(cd $(PKG_BUILD_DIR)/frontend/dist && find . -type f -name '*.gz' -exec cp --parents {} $(1)/opt/usr/share/keen-pbr/frontend/ \;)
+	chmod -R a=rX,u+w $(1)/opt/usr/share/keen-pbr/frontend
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/config.example.json $(1)/opt/etc/keen-pbr/config.json
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/packages/common/local.lst $(1)/opt/etc/keen-pbr/local.lst
 endef

--- a/packages/openwrt/keen-pbr/Makefile
+++ b/packages/openwrt/keen-pbr/Makefile
@@ -50,7 +50,7 @@ define Package/keen-pbr/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/openwrt/keen-pbr/files/etc/hotplug.d/firewall/70-keen-pbr $(1)/etc/hotplug.d/firewall/70-keen-pbr
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/openwrt/keen-pbr/files/etc/hotplug.d/iface/70-keen-pbr $(1)/etc/hotplug.d/iface/70-keen-pbr
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/openwrt/keen-pbr/files/usr/lib/keen-pbr/dnsmasq.sh $(1)/usr/lib/keen-pbr/dnsmasq.sh
-	(cd $(PKG_BUILD_DIR)/frontend/dist && find . -type f -name '*.gz' -exec cp --parents {} $(1)/usr/share/keen-pbr/frontend/ \;)
+	$(CP) $(PKG_BUILD_DIR)/frontend/dist/. $(1)/usr/share/keen-pbr/frontend/
 	chmod -R a=rX,u+w $(1)/usr/share/keen-pbr/frontend
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/config.example.json $(1)/etc/keen-pbr/config.json
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/packages/common/local.lst $(1)/etc/keen-pbr/local.lst

--- a/packages/openwrt/keen-pbr/Makefile
+++ b/packages/openwrt/keen-pbr/Makefile
@@ -23,11 +23,7 @@ KEEN_PBR_SRC ?= /home/me/keen-pbr-src
 define Build/Prepare
 	mkdir -p $(PKG_BUILD_DIR)
 	cp -a $(KEEN_PBR_SRC)/. $(PKG_BUILD_DIR)/
-endef
-
-define Build/Compile
-	(cd $(PKG_BUILD_DIR)/frontend && bun install --frozen-lockfile && bun run build)
-	$(call Build/Compile/Default)
+	@test -d $(PKG_BUILD_DIR)/frontend/dist || (echo "Missing frontend/dist (provide frontend-build artifacts in KEEN_PBR_SRC)"; false)
 endef
 
 CMAKE_OPTIONS += \

--- a/packages/openwrt/keen-pbr/Makefile
+++ b/packages/openwrt/keen-pbr/Makefile
@@ -25,6 +25,11 @@ define Build/Prepare
 	cp -a $(KEEN_PBR_SRC)/. $(PKG_BUILD_DIR)/
 endef
 
+define Build/Compile
+	(cd $(PKG_BUILD_DIR)/frontend && bun install --frozen-lockfile && bun run build)
+	$(call Build/Compile/Default)
+endef
+
 CMAKE_OPTIONS += \
 	-DKEEN_PBR_DEFAULT_CONFIG_PATH:STRING=/etc/keen-pbr/config.json \
 	-DKEEN_PBR_FRONTEND_ROOT:STRING=/usr/share/keen-pbr/frontend \
@@ -43,11 +48,14 @@ define Package/keen-pbr/install
 	$(INSTALL_DIR) $(1)/etc/keen-pbr
 	$(INSTALL_DIR) $(1)/usr/lib/keen-pbr
 	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/usr/share/keen-pbr/frontend
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/keen-pbr $(1)/usr/sbin/keen-pbr
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/openwrt/keen-pbr/files/etc/init.d/keen-pbr $(1)/etc/init.d/keen-pbr
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/openwrt/keen-pbr/files/etc/hotplug.d/firewall/70-keen-pbr $(1)/etc/hotplug.d/firewall/70-keen-pbr
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/openwrt/keen-pbr/files/etc/hotplug.d/iface/70-keen-pbr $(1)/etc/hotplug.d/iface/70-keen-pbr
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/packages/openwrt/keen-pbr/files/usr/lib/keen-pbr/dnsmasq.sh $(1)/usr/lib/keen-pbr/dnsmasq.sh
+	(cd $(PKG_BUILD_DIR)/frontend/dist && find . -type f -name '*.gz' -exec cp --parents {} $(1)/usr/share/keen-pbr/frontend/ \;)
+	chmod -R a=rX,u+w $(1)/usr/share/keen-pbr/frontend
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/config.example.json $(1)/etc/keen-pbr/config.json
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/packages/common/local.lst $(1)/etc/keen-pbr/local.lst
 endef


### PR DESCRIPTION
### Motivation
- Ensure the web frontend is built and included in the keen-pbr packages so routers receive the compiled UI assets.
- Integrate the frontend build step into the OpenWrt/keenetic package flow so the package output contains `frontend` files under the correct runtime paths.

### Description
- Added a `Build/Compile` step to both `packages/keenetic/keen-pbr/Makefile` and `packages/openwrt/keen-pbr/Makefile` that runs `bun install --frozen-lockfile` and `bun run build` inside the `frontend` directory before calling the default compile. 
- Created package install directories for the frontend by adding `$(INSTALL_DIR) .../frontend` to both Makefiles and copied gzipped build artifacts from `$(PKG_BUILD_DIR)/frontend/dist` into the package using `find ... -name '*.gz' -exec cp --parents {}`.
- Set permissions on the installed frontend with `chmod -R a=rX,u+w` and preserved existing packaging of binaries and config files for both OpenWrt and Keenetic variants.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02d5a252c832a9fd97153e7363e2c)