### PR TITLE
Add sidebar theme selector with persisted override

### DIFF
--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -8,11 +8,13 @@ import {
 } from "lucide-react"
 
 import { AppBrandHeader } from "@/components/layout/app-brand-header"
+import { ThemeSelector } from "@/components/theme-selector"
 import { WarningBanner } from "@/components/layout/warning-banner"
 import { NavMain } from "@/components/nav-main"
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
   SidebarHeader
 } from "@/components/ui/sidebar"
 import { useSidebar } from "@/components/ui/sidebar-context"
@@ -83,6 +85,9 @@ export function AppSidebar(props: ComponentProps<typeof Sidebar>) {
         {!isMobile ? <WarningBanner className="mx-2 mt-2 mb-0 w-auto" compact /> : null}
         <NavMain items={data.navMain} />
       </SidebarContent>
+      <SidebarFooter className={isMobile ? "border-t px-4 py-3" : "border-t"}>
+        <ThemeSelector />
+      </SidebarFooter>
     </Sidebar>
   )
 }

--- a/frontend/src/components/theme-selector.tsx
+++ b/frontend/src/components/theme-selector.tsx
@@ -1,0 +1,40 @@
+import { useTheme } from "@/components/theme-provider"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+const THEME_OPTIONS = [
+  { value: "system", label: "Use system setting" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+] as const
+
+export function ThemeSelector() {
+  const { theme, setTheme } = useTheme()
+
+  return (
+    <div className="space-y-2">
+      <p className="px-1 text-xs font-medium text-sidebar-foreground/70">Theme</p>
+      <Select
+        defaultValue={theme}
+        onValueChange={(value) => setTheme(value as "system" | "light" | "dark")}
+        value={theme}
+      >
+        <SelectTrigger aria-label="Theme selector" className="bg-sidebar">
+          <SelectValue placeholder="Use system setting" />
+        </SelectTrigger>
+        <SelectContent align="start">
+          {THEME_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a simple user control to switch between `system`/`light`/`dark` themes from the sidebar and allow users to override the system preference and persist that choice in the browser.
- Use the existing `ThemeProvider` (which applies global `.light`/`.dark` classes and handles `localStorage`) and `shadcn`/`@base-ui` primitives so no per-component theme rules are introduced.

### Description
- Added a new `ThemeSelector` component at `frontend/src/components/theme-selector.tsx` that uses the existing `Select` primitives to expose `Use system setting`, `Light`, and `Dark` options and calls `setTheme` from `useTheme` to apply and persist the selection.
- Placed the selector in the sidebar footer by updating `frontend/src/components/app-sidebar.tsx` so it appears at the bottom on desktop and mobile via the shared `SidebarFooter` slot.
- No component-level styling changes were introduced; theme application relies on the existing `ThemeProvider` logic in `frontend/src/components/theme-provider.tsx` which maps the selected theme to global root classes and `localStorage`.

### Testing
- `make` (root build) failed in this environment during CMake configuration due to a missing system package `libnl-3.0`. (failure)
- `cd frontend && bun install` completed successfully. (success)
- `cd frontend && bun run build` completed successfully and produced a production build under `dist/`. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02f12d734832ab6bf408d8b7521e6)