### PR TITLE
Add optional Keenetic DNS server type resolved from RCI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ add_link_options(-rdynamic)
 
 # Options
 option(WITH_API "Build with REST API support (cpp-httplib)" ON)
+option(USE_KEENETIC_API "Enable Keenetic RCI integration (DNS server type: keenetic)" OFF)
 set(KEEN_PBR_DEFAULT_CONFIG_PATH "/etc/keen-pbr/config.json" CACHE STRING
   "Default config file path used by keen-pbr when --config is not passed")
 set(KEEN_PBR_FRONTEND_ROOT "/usr/share/keen-pbr/frontend" CACHE STRING
@@ -93,6 +94,7 @@ set(SOURCES
   src/firewall/iptables_verifier.cpp
   src/firewall/nftables_verifier.cpp
   src/dns/dns_server.cpp
+  src/dns/keenetic_dns.cpp
   src/dns/dns_txt_client.cpp
   src/dns/dns_probe_server.cpp
   src/dns/dns_router.cpp
@@ -129,6 +131,9 @@ target_compile_definitions(keen-pbr PRIVATE
   KEEN_PBR_DEFAULT_CONFIG_PATH="${KEEN_PBR_DEFAULT_CONFIG_PATH}"
   KEEN_PBR_FRONTEND_ROOT="${KEEN_PBR_FRONTEND_ROOT}"
 )
+if(USE_KEENETIC_API)
+  target_compile_definitions(keen-pbr PRIVATE USE_KEENETIC_API)
+endif()
 target_link_libraries(keen-pbr PRIVATE
   CURL::libcurl
   PkgConfig::LIBNL

--- a/config.example.json
+++ b/config.example.json
@@ -99,11 +99,16 @@
     "servers": [
       {
         "tag": "vpn-dns",
+        "type": "static",
         "address": "10.8.0.1"
       },
       {
         "tag": "google-dns",
         "address": "8.8.8.8"
+      },
+      {
+        "tag": "keenetic-dns",
+        "type": "keenetic"
       }
     ],
     "rules": [

--- a/docs/content/docs/configuration/dns.md
+++ b/docs/content/docs/configuration/dns.md
@@ -54,12 +54,13 @@ event per queried DNS name observed while that connection stays open.
 
 ## DNS Servers
 
-Each server has a tag, an address, and an optional `detour`.
+Each server has a tag, optional `type`, optional `address`, and optional `detour`.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `tag` | string | yes | Unique identifier for this DNS server |
-| `address` | string | yes | IPv4 or IPv6 address of the DNS server, with optional port: `"8.8.8.8"`, `"8.8.8.8:5353"`, `"[::1]:5353"`. Default port: 53. |
+| `type` | string | no | DNS source type: `static` (default) or `keenetic`. |
+| `address` | string | for `static` | IPv4 or IPv6 address of the DNS server, with optional port: `"8.8.8.8"`, `"8.8.8.8:5353"`, `"[::1]:5353"`. Default port: 53. |
 | `detour` | string | no | Outbound tag to use when querying this server |
 
 The `detour` field binds DNS queries for this server to a specific outbound. This ensures that DNS resolution goes through the same path as the routed traffic.
@@ -69,16 +70,31 @@ The `detour` field binds DNS queries for this server to a specific outbound. Thi
   "servers": [
     {
       "tag": "vpn-dns",
+      "type": "static",
       "address": "10.8.0.1",
       "detour": "vpn"
     },
     {
       "tag": "google-dns",
       "address": "8.8.8.8"
+    },
+    {
+      "tag": "keenetic-dns",
+      "type": "keenetic"
     }
   ]
 }
 ```
+
+### `type: keenetic` (built-in router DNS via RCI)
+
+When `type` is set to `keenetic`, `keen-pbr` resolves the DNS server address from Keenetic RCI at startup, on config reload, and after manual restart via UI reload flow.
+
+- Compile-time requirement: `USE_KEENETIC_API=ON`.
+- Source of truth endpoint: `GET http://127.0.0.1:79/rci/show/dns-proxy`.
+- Data source inside response: `proxy-status[]` entry with `proxy-name == "System"`, field `proxy-config`, first `dns_server = ...` directive.
+
+If Keenetic API support is not compiled in, config with `type: "keenetic"` fails validation with a clear diagnostic.
 
 ### How `detour` works
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -392,16 +392,23 @@ components:
 
     DnsServer:
       type: object
-      required: [tag, address]
+      required: [tag]
       properties:
         tag:
           type: string
           description: Unique identifier for this DNS server.
           example: "vpn-dns"
+        type:
+          type: string
+          description: DNS server source type.
+          enum: [static, keenetic]
+          default: static
+          example: "static"
         address:
           type: string
           description: >
             IPv4 or IPv6 address of the DNS server, with optional port.
+            Required for `type=static`. Must be omitted for `type=keenetic`.
             Formats: "8.8.8.8", "8.8.8.8:5353", "::1", "[::1]:5353".
             Default port is 53.
           example: "10.8.0.1"

--- a/packages/keenetic/keen-pbr/Makefile
+++ b/packages/keenetic/keen-pbr/Makefile
@@ -30,6 +30,7 @@ CMAKE_OPTIONS += \
 	-DKEEN_PBR_DEFAULT_CONFIG_PATH:STRING=/opt/etc/keen-pbr/config.json \
 	-DKEEN_PBR_FRONTEND_ROOT:STRING=/opt/usr/share/keen-pbr/frontend \
 	-DWITH_API=ON \
+	-DUSE_KEENETIC_API=ON \
 	-DCMAKE_BUILD_TYPE=MinSizeRel
 
 define Package/keen-pbr/conffiles

--- a/src/api/generated/api_types.hpp
+++ b/src/api/generated/api_types.hpp
@@ -131,9 +131,10 @@ namespace api {
     };
 
     struct DnsServerElement {
-        std::string address;
+        std::optional<std::string> address;
         std::optional<std::string> detour;
         std::string tag;
+        std::optional<std::string> type;
     };
 
     enum class DnsSystemResolverType : int { DNSMASQ_IPSET, DNSMASQ_NFTSET };
@@ -670,9 +671,10 @@ namespace api {
     }
 
     inline void from_json(const json & j, DnsServerElement& x) {
-        x.address = j.at("address").get<std::string>();
+        x.address = get_stack_optional<std::string>(j, "address");
         x.detour = get_stack_optional<std::string>(j, "detour");
         x.tag = j.at("tag").get<std::string>();
+        x.type = get_stack_optional<std::string>(j, "type");
     }
 
     inline void to_json(json & j, const DnsServerElement & x) {
@@ -680,6 +682,7 @@ namespace api {
         j["address"] = x.address;
         j["detour"] = x.detour;
         j["tag"] = x.tag;
+        j["type"] = x.type;
     }
 
     inline void from_json(const json & j, SystemResolver& x) {

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -280,6 +280,32 @@ Config parse_config(const std::string& json_str) {
     if (cfg.dns.has_value()) {
         const auto& dns_servers = cfg.dns->servers.value_or(std::vector<DnsServer>{});
         for (const auto& srv : dns_servers) {
+            const std::string srv_type = srv.type.value_or("static");
+            if (srv_type != "static" && srv_type != "keenetic") {
+                add_issue(issues, "dns.servers." + srv.tag + ".type",
+                          "dns.servers[\"" + srv.tag +
+                              "\"].type must be one of: static, keenetic");
+            }
+
+            if (srv_type == "keenetic") {
+#ifndef USE_KEENETIC_API
+                add_issue(issues, "dns.servers." + srv.tag + ".type",
+                          "dns.servers[\"" + srv.tag +
+                              "\"].type='keenetic' requires build with USE_KEENETIC_API=ON");
+#endif
+                if (srv.address.has_value() && !srv.address->empty()) {
+                    add_issue(issues, "dns.servers." + srv.tag + ".address",
+                              "dns.servers[\"" + srv.tag +
+                                  "\"].address must not be set for type='keenetic' (resolved via RCI)");
+                }
+            } else {
+                if (!srv.address.has_value() || srv.address->empty()) {
+                    add_issue(issues, "dns.servers." + srv.tag + ".address",
+                              "dns.servers[\"" + srv.tag +
+                                  "\"].address is required for type='static'");
+                }
+            }
+
             if (!srv.detour.has_value()) continue;
 
             const std::string& dtag = srv.detour.value();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -635,6 +635,7 @@ void Daemon::apply_firewall() {
     if (config_.dns.has_value()) {
         const auto& dns_servers =
             config_.dns->servers.value_or(std::vector<DnsServer>{});
+        const DnsServerRegistry dns_registry(config_.dns.value_or(DnsConfig{}));
         for (const auto& srv : dns_servers) {
             if (!srv.detour.has_value()) continue;
 
@@ -655,11 +656,14 @@ void Daemon::apply_firewall() {
             auto mark_it = outbound_marks_.find(effective_tag);
             if (mark_it == outbound_marks_.end()) continue;
 
-            auto parsed = parse_dns_address_str(srv.address);
+            const DnsServerConfig* resolved_server = dns_registry.get_server(srv.tag);
+            if (!resolved_server) {
+                throw DaemonError("DNS server tag not found during detour setup: " + srv.tag);
+            }
             ProtoPortFilter filter;
             filter.proto    = "tcp/udp";
-            filter.dst_port = std::to_string(parsed.port);
-            filter.dst_addr = {parsed.ip};
+            filter.dst_port = std::to_string(resolved_server->port);
+            filter.dst_addr = {resolved_server->resolved_ip};
             firewall_->create_direct_mark_rule(mark_it->second, filter);
         }
     }

--- a/src/dns/dns_router.cpp
+++ b/src/dns/dns_router.cpp
@@ -1,4 +1,5 @@
 #include "dns_router.hpp"
+#include "keenetic_dns.hpp"
 
 namespace keen_pbr3 {
 
@@ -6,9 +7,21 @@ DnsServerRegistry::DnsServerRegistry(const DnsConfig& dns_config)
     : fallback_tag_(dns_config.fallback.value_or("")) {
     // Parse all DNS server definitions into DnsServerConfig
     for (const auto& server : dns_config.servers.value_or(std::vector<DnsServer>{})) {
+        const std::string server_type = server.type.value_or("static");
+        std::string resolved_address;
+        if (server_type == "keenetic") {
+            resolved_address = resolve_keenetic_dns_address();
+        } else if (server_type == "static") {
+            if (!server.address.has_value()) {
+                throw DnsError("DNS server '" + server.tag + "' is missing address");
+            }
+            resolved_address = *server.address;
+        } else {
+            throw DnsError("DNS server '" + server.tag + "' has unsupported type: " + server_type);
+        }
         servers_.emplace(
             server.tag,
-            parse_dns_server(server.tag, server.address, server.detour));
+            parse_dns_server(server.tag, resolved_address, server.detour));
     }
 
     // Validate that fallback server tag exists

--- a/src/dns/keenetic_dns.cpp
+++ b/src/dns/keenetic_dns.cpp
@@ -1,0 +1,132 @@
+#include "keenetic_dns.hpp"
+
+#include "dns_server.hpp"
+
+#include "../http/http_client.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <cctype>
+#include <sstream>
+
+namespace keen_pbr3 {
+
+namespace {
+
+constexpr const char* kRciDnsProxyEndpoint = "http://127.0.0.1:79/rci/show/dns-proxy";
+
+std::string trim_copy(const std::string& s) {
+    size_t begin = 0;
+    while (begin < s.size() && std::isspace(static_cast<unsigned char>(s[begin]))) {
+        ++begin;
+    }
+    size_t end = s.size();
+    while (end > begin && std::isspace(static_cast<unsigned char>(s[end - 1]))) {
+        --end;
+    }
+    return s.substr(begin, end - begin);
+}
+
+std::string extract_address_from_dns_server_line(const std::string& line) {
+    constexpr const char* kPrefix = "dns_server = ";
+    if (line.rfind(kPrefix, 0) != 0) {
+        return "";
+    }
+
+    std::string rest = trim_copy(line.substr(std::char_traits<char>::length(kPrefix)));
+    const auto comment_pos = rest.find('#');
+    if (comment_pos != std::string::npos) {
+        rest = trim_copy(rest.substr(0, comment_pos));
+    }
+    if (rest.empty()) {
+        return "";
+    }
+
+    const auto first_space = rest.find_first_of(" \t");
+    if (first_space != std::string::npos) {
+        rest = rest.substr(0, first_space);
+    }
+    return trim_copy(rest);
+}
+
+} // namespace
+
+std::string extract_keenetic_dns_address_from_rci(const std::string& response_body) {
+    using json = nlohmann::json;
+
+    json doc;
+    try {
+        doc = json::parse(response_body);
+    } catch (const std::exception& e) {
+        throw KeeneticDnsError(std::string("Failed to parse RCI JSON response: ") + e.what());
+    }
+
+    const auto status_it = doc.find("proxy-status");
+    if (status_it == doc.end() || !status_it->is_array()) {
+        throw KeeneticDnsError(
+            "RCI response missing 'proxy-status' array (endpoint: /rci/show/dns-proxy)");
+    }
+
+    for (const auto& entry : *status_it) {
+        if (!entry.is_object()) {
+            continue;
+        }
+
+        const auto name_it = entry.find("proxy-name");
+        if (name_it == entry.end() || !name_it->is_string()) {
+            continue;
+        }
+        if (name_it->get<std::string>() != "System") {
+            continue;
+        }
+
+        const auto cfg_it = entry.find("proxy-config");
+        if (cfg_it == entry.end() || !cfg_it->is_string()) {
+            throw KeeneticDnsError(
+                "RCI response has 'System' DNS proxy but missing string field 'proxy-config'");
+        }
+
+        std::istringstream in(cfg_it->get<std::string>());
+        std::string line;
+        while (std::getline(in, line)) {
+            const std::string address = extract_address_from_dns_server_line(trim_copy(line));
+            if (address.empty()) {
+                continue;
+            }
+
+            try {
+                (void)parse_dns_address_str(address);
+            } catch (const DnsError& e) {
+                throw KeeneticDnsError(
+                    "RCI returned invalid dns_server address '" + address + "': " + e.what());
+            }
+            return address;
+        }
+
+        throw KeeneticDnsError(
+            "Built-in DNS proxy appears disabled or has no 'dns_server = ...' directives in System policy");
+    }
+
+    throw KeeneticDnsError(
+        "RCI response does not contain DNS proxy policy 'System' (endpoint: /rci/show/dns-proxy)");
+}
+
+std::string resolve_keenetic_dns_address() {
+#ifdef USE_KEENETIC_API
+    try {
+        HttpClient client;
+        client.set_timeout(std::chrono::seconds(3));
+        const std::string response = client.download(kRciDnsProxyEndpoint);
+        return extract_keenetic_dns_address_from_rci(response);
+    } catch (const HttpError& e) {
+        throw KeeneticDnsError(
+            "Failed to query Keenetic RCI endpoint /rci/show/dns-proxy: " +
+            std::string(e.what()));
+    }
+#else
+    throw KeeneticDnsError(
+        "DNS server type 'keenetic' requires build with USE_KEENETIC_API=ON");
+#endif
+}
+
+} // namespace keen_pbr3

--- a/src/dns/keenetic_dns.hpp
+++ b/src/dns/keenetic_dns.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace keen_pbr3 {
+
+class KeeneticDnsError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+// RCI endpoint used as source of truth for the built-in DNS proxy:
+// GET http://127.0.0.1:79/rci/show/dns-proxy
+//
+// We read proxy-status entry with proxy-name == "System" and parse the first
+// "dns_server = ..." directive from proxy-config.
+std::string extract_keenetic_dns_address_from_rci(const std::string& response_body);
+
+// Resolve built-in DNS server address via Keenetic RCI.
+// Throws KeeneticDnsError on network/protocol/parse/validation errors.
+std::string resolve_keenetic_dns_address();
+
+} // namespace keen_pbr3

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(keen-pbr-tests
   test_addr_spec.cpp
   test_dnsmasq_gen.cpp
   test_dns_server.cpp
+  test_keenetic_dns.cpp
   test_dns_probe_server.cpp
   test_list_set_usage.cpp
   test_config_validation.cpp
@@ -25,6 +26,7 @@ add_executable(keen-pbr-tests
   ../src/dns/dnsmasq_gen.cpp
   ../src/dns/dns_router.cpp
   ../src/dns/dns_server.cpp
+  ../src/dns/keenetic_dns.cpp
   ../src/daemon/system_resolver_hook.cpp
   ../src/dns/dns_probe_server.cpp
   ../src/cache/cache_manager.cpp
@@ -64,4 +66,8 @@ target_link_libraries(keen-pbr-tests PRIVATE
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
   target_link_libraries(keen-pbr-tests PRIVATE stdc++fs)
+endif()
+
+if(USE_KEENETIC_API)
+  target_compile_definitions(keen-pbr-tests PRIVATE USE_KEENETIC_API)
 endif()

--- a/tests/test_keenetic_dns.cpp
+++ b/tests/test_keenetic_dns.cpp
@@ -1,0 +1,38 @@
+#include <doctest/doctest.h>
+
+#include "../src/dns/keenetic_dns.hpp"
+#include "../src/config/config.hpp"
+
+using namespace keen_pbr3;
+
+TEST_CASE("keenetic dns: parse address from RCI System policy") {
+    const std::string json = R"({
+      "proxy-status": [
+        {"proxy-name":"Guest","proxy-config":"dns_server = 8.8.8.8\n"},
+        {"proxy-name":"System","proxy-config":"dns_server = 127.0.0.1:40500 # https://dns.example/dns-query@dnsm\n"}
+      ]
+    })";
+
+    CHECK(extract_keenetic_dns_address_from_rci(json) == "127.0.0.1:40500");
+}
+
+TEST_CASE("keenetic dns: invalid RCI response is rejected") {
+    CHECK_THROWS_AS(extract_keenetic_dns_address_from_rci(R"({"proxy-status":[]})"),
+                    KeeneticDnsError);
+    CHECK_THROWS_AS(extract_keenetic_dns_address_from_rci(R"({"proxy-status":[{"proxy-name":"System","proxy-config":"dns_server = not-an-ip"}]})"),
+                    KeeneticDnsError);
+}
+
+#ifndef USE_KEENETIC_API
+TEST_CASE("config: type=keenetic rejected when feature disabled") {
+    const std::string json = R"({
+      "dns": {
+        "servers": [
+          {"tag": "keenetic-dns", "type": "keenetic"}
+        ]
+      }
+    })";
+    CHECK_THROWS_AS(parse_config(json), ConfigValidationError);
+}
+#endif
+


### PR DESCRIPTION
### Motivation
- Allow reusing the router's built-in DNS proxy as a DNS server in the configuration via a new `type: "keenetic"` so the service can use the router-provided IP for DoH/DoT without duplicating logic.
- Make this feature opt-in at compile time so builds that don't need Keenetic RCI integration remain lean and fail clearly if misconfigured.

### Description
- Add CMake option `USE_KEENETIC_API` and wire `-DUSE_KEENETIC_API` into the target when enabled, and include new source `src/dns/keenetic_dns.cpp` in the build and tests when applicable.
- Extend the API model: `DnsServerElement.address` is now optional and `DnsServerElement.type` (optional) supports `static` (default) and `keenetic`, and update (de)serialization accordingly.
- Add config validation in `parse_config` to enforce `type` ∈ {`static`,`keenetic`}, require `address` for `static`, forbid `address` for `keenetic`, and emit a clear validation error when `keenetic` is used but `USE_KEENETIC_API` is not enabled at build time.
- Implement Keenetic RCI resolver (`src/dns/keenetic_dns.{hpp,cpp}`) that queries `GET http://127.0.0.1:79/rci/show/dns-proxy`, finds the `proxy-status[]` entry with `proxy-name == "System"`, parses the first `dns_server = ...` line, validates it with existing DNS parsing, and surfaces detailed errors for network/JSON/parse/validation failures.
- Integrate resolution into the existing DNS pipeline by resolving `type: "keenetic"` into a normal address before `parse_dns_server` in `DnsServerRegistry`, and make daemon detour firewall rules use the resolved `DnsServerConfig` (IP/port) so the rest of the pipeline treats it the same as static servers.
- Add unit tests `tests/test_keenetic_dns.cpp` that cover RCI response parsing and the validation path when the feature is disabled, and update docs/openapi and `config.example.json` with the new `type` contract and RCI endpoint details.

### Testing
- `make` (native build) failed during CMake configure in this environment due to a missing system dependency: pkg-config cannot find `libnl-3.0`, so full build/test run could not be completed.
- `jq empty config.example.json` succeeded to validate the example JSON after changes.
- Added unit tests (`tests/test_keenetic_dns.cpp`) but they were not executed here because the project could not be configured/built due to the missing `libnl-3.0` dependency; tests are expected to pass when built in a proper environment with `BUILD_TESTS=ON` and required system libs installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03c12c520832a90bf1a7ed104328c)