### PR TITLE
Align expected firewall set checks with actual set creation

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -526,11 +526,16 @@ void Daemon::apply_firewall() {
 
     for (size_t rule_idx = 0; rule_idx < route_rules.size(); ++rule_idx) {
         const auto& rule = route_rules[rule_idx];
-        const RuleState& rs = rule_states[rule_idx];
+        RuleState& rs = rule_states[rule_idx];
 
         if (rs.action_type == RuleActionType::Skip) {
             continue;
         }
+
+        // Keep expected firewall state aligned with what we actually create.
+        // build_fw_rule_states() pre-populates all static/dynamic set variants,
+        // but apply_firewall() intentionally skips sets that would be always empty.
+        rs.set_names.clear();
 
         const bool is_blackhole = (rs.action_type == RuleActionType::Drop);
 
@@ -558,6 +563,8 @@ void Daemon::apply_firewall() {
             if (usage.has_static_entries) {
                 firewall_->create_ipset(set4, AF_INET, 0);
                 firewall_->create_ipset(set6, AF_INET6, 0);
+                rs.set_names.push_back(set4);
+                rs.set_names.push_back(set6);
 
                 auto loader4 = firewall_->create_batch_loader(set4);
                 auto loader6 = firewall_->create_batch_loader(set6);
@@ -575,6 +582,8 @@ void Daemon::apply_firewall() {
             if (usage.has_domain_entries) {
                 firewall_->create_ipset(set4d, AF_INET, usage.dynamic_timeout);
                 firewall_->create_ipset(set6d, AF_INET6, usage.dynamic_timeout);
+                rs.set_names.push_back(set4d);
+                rs.set_names.push_back(set6d);
             }
 
             // Build proto/port/addr filter from route rule.


### PR DESCRIPTION
### Motivation

- Health checks reported missing ipsets/nftsets for sets that were intentionally never created when a list had no IP/CIDR or domain entries. 
- The expected `RuleState::set_names` was pre-populated during state construction but not updated to match the conditional creation logic used in `apply_firewall()`, causing create vs check mismatch. 

### Description

- Make `Daemon::apply_firewall()` use a mutable `RuleState&` and clear `rs.set_names` so expected sets are rebuilt from the actual creation path. 
- Only append static (`kpbr4_/kpbr6_`) and dynamic (`kpbr4d_/kpbr6d_`) set names to `rs.set_names` when `analyze_list_set_usage()` indicates `has_static_entries` or `has_domain_entries`, respectively. 
- This change keeps the verifier input aligned with the same `usage` decisions used to call `firewall_->create_ipset(...)`. 
- Change is implemented in `src/daemon/daemon.cpp` within the firewall apply loop that processes route rules and lists.

### Testing

- Attempted to build with `make`, but the CMake configure step failed due to a missing system dependency `libnl-3.0`, so no successful build artifacts were produced. 
- No other automated tests could be executed in this environment because of the same missing dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c228acc2f8832a9a90ba821c9ef45b)