### PR TITLE
Fix curl init race, PIMPL leak, and DNS probe server hardening

### DIFF
--- a/src/dns/dns_probe_server.cpp
+++ b/src/dns/dns_probe_server.cpp
@@ -24,6 +24,8 @@ constexpr uint16_t DNS_TYPE_OPT = 41;
 constexpr uint16_t DNS_FLAG_QR = 0x8000;
 constexpr uint16_t DNS_FLAG_RD = 0x0100;
 constexpr uint16_t DNS_EDNS_OPTION_ECS = 8;
+constexpr size_t kMaxTcpClients = 16;
+constexpr size_t kMaxTcpBufferSize = 16384;
 
 bool is_valid_ipv4(const std::string& ip) {
     struct in_addr addr {};
@@ -438,6 +440,10 @@ std::vector<int> DnsProbeServer::accept_tcp_clients() {
     while (true) {
         int client_fd = accept4(tcp_fd_, nullptr, nullptr, SOCK_CLOEXEC | SOCK_NONBLOCK);
         if (client_fd >= 0) {
+            if (tcp_clients_.size() >= kMaxTcpClients) {
+                close(client_fd);
+                break;
+            }
             tcp_clients_.emplace(client_fd, TcpClientState{});
             accepted.push_back(client_fd);
             continue;
@@ -528,6 +534,10 @@ bool DnsProbeServer::handle_tcp_client_readable(int fd) {
         ssize_t n = recv(fd, buf, sizeof(buf), 0);
         if (n > 0) {
             state.buffer.insert(state.buffer.end(), buf, buf + n);
+            if (state.buffer.size() > kMaxTcpBufferSize) {
+                Logger::instance().warn("DNS test server TCP buffer exceeded limit, closing connection");
+                return false;
+            }
             if (!state.have_size && state.buffer.size() >= 2) {
                 state.expected_size = static_cast<uint16_t>((state.buffer[0] << 8) | state.buffer[1]);
                 state.have_size = true;

--- a/src/health/url_tester.cpp
+++ b/src/health/url_tester.cpp
@@ -1,6 +1,7 @@
 #include "url_tester.hpp"
 
 #include <chrono>
+#include <cstdint>
 #include <curl/curl.h>
 #include <sys/socket.h>
 #include <thread>
@@ -10,6 +11,7 @@ namespace keen_pbr3 {
 // Discard response body
 static size_t discard_callback(char* /*ptr*/, size_t size, size_t nmemb,
                                void* /*userdata*/) {
+    if (nmemb != 0 && size > SIZE_MAX / nmemb) return 0;
     return size * nmemb;
 }
 
@@ -23,13 +25,7 @@ static int sockopt_callback(void* clientp, curl_socket_t curlfd,
     return CURL_SOCKOPT_OK;
 }
 
-URLTester::URLTester() {
-    static bool curl_initialized = [] {
-        curl_global_init(CURL_GLOBAL_DEFAULT);
-        return true;
-    }();
-    (void)curl_initialized;
-}
+URLTester::URLTester() {}
 
 URLTester::~URLTester() = default;
 

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -1,6 +1,7 @@
 #include "http_client.hpp"
 
 #include <algorithm>
+#include <cstdint>
 #include <curl/curl.h>
 #include <sys/socket.h>
 
@@ -16,6 +17,7 @@ long HttpError::status_code() const noexcept { return status_code_; }
 // write callback for libcurl
 static size_t write_callback(char* ptr, size_t size, size_t nmemb,
                              void* userdata) {
+    if (nmemb != 0 && size > SIZE_MAX / nmemb) return 0;
     auto* body = static_cast<std::string*>(userdata);
     size_t total = size * nmemb;
     body->append(ptr, total);
@@ -44,6 +46,7 @@ static std::string trim_header_value(const std::string& s) {
 
 static size_t header_callback(char* buffer, size_t size, size_t nitems,
                               void* userdata) {
+    if (nitems != 0 && size > SIZE_MAX / nitems) return 0;
     size_t total = size * nitems;
     auto* capture = static_cast<HeaderCapture*>(userdata);
     std::string header(buffer, total);
@@ -70,13 +73,7 @@ static size_t header_callback(char* buffer, size_t size, size_t nitems,
 
 // HttpClient
 
-HttpClient::HttpClient() {
-    static bool curl_initialized = [] {
-        curl_global_init(CURL_GLOBAL_DEFAULT);
-        return true;
-    }();
-    (void)curl_initialized;
-}
+HttpClient::HttpClient() {}
 
 HttpClient::~HttpClient() = default;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #  define KEEN_HAS_EXECINFO 0
 #endif
 
+#include <curl/curl.h>
 #include <keen-pbr/version.hpp>
 
 #include "cache/cache_manager.hpp"
@@ -211,6 +212,13 @@ std::string read_file(const std::string& path) {
 
 int main(int argc, char* argv[]) {
     install_crash_handler();
+
+    struct CurlGuard {
+        CurlGuard() { curl_global_init(CURL_GLOBAL_DEFAULT); }
+        ~CurlGuard() { curl_global_cleanup(); }
+    };
+    CurlGuard curl_guard;
+
     CliOptions opts = parse_args(argc, argv);
 
     if (opts.show_version) {

--- a/src/routing/netlink.cpp
+++ b/src/routing/netlink.cpp
@@ -123,11 +123,9 @@ struct NetlinkManager::Impl {
     }
 };
 
-NetlinkManager::NetlinkManager() : impl_(new Impl()) {}
+NetlinkManager::NetlinkManager() : impl_(std::make_unique<Impl>()) {}
 
-NetlinkManager::~NetlinkManager() {
-    delete impl_;
-}
+NetlinkManager::~NetlinkManager() = default;
 
 void NetlinkManager::add_route(const RouteSpec& spec) {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/src/routing/netlink.hpp
+++ b/src/routing/netlink.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
@@ -94,7 +95,7 @@ public:
 
 private:
     struct Impl;
-    Impl* impl_;
+    std::unique_ptr<Impl> impl_;
     mutable std::mutex mutex_;
 };
 


### PR DESCRIPTION
## Summary
- **curl_global_init() race:** Moved the single `curl_global_init()` call into `main()` with an RAII guard (`CurlGuard`), removing duplicate static initializers from `HttpClient` and `URLTester` constructors that risked concurrent calls from separate threads.
- **Raw new/delete PIMPL:** Replaced `Impl* impl_` with `std::unique_ptr<Impl>` in `NetlinkManager`, eliminating memory leak risk if the constructor body throws.
- **Unbounded TCP buffer:** Capped DNS probe server TCP client buffer at 16 KB; connections exceeding the limit are closed.
- **No TCP connection limit:** Limited concurrent DNS probe TCP connections to 16; excess connections are immediately closed.
- **size×nmemb overflow:** Added `SIZE_MAX` overflow checks before multiplication in all curl write/header callbacks, preventing UB on 32-bit MIPS.

## Test plan
- [x] Project compiles cleanly (`cmake --build build`)
- [x] All 277 unit tests pass (`keen-pbr-tests`)
- [ ] Verify no remaining `curl_global_init` calls outside `main.cpp`
- [ ] Manual test on MIPS target device

https://claude.ai/code/session_01JyGhNBqx2CVTpd43Hj2C9v