### PR TITLE
Fix P0 shell injection vulnerabilities in system() calls

### DIFF
--- a/src/daemon/system_resolver_hook.cpp
+++ b/src/daemon/system_resolver_hook.cpp
@@ -1,11 +1,10 @@
 #include "system_resolver_hook.hpp"
 
-#include <cstdlib>
-#include <sys/wait.h>
+#include "../util/safe_exec.hpp"
 
 namespace keen_pbr3 {
 
-std::string build_system_resolver_reload_command(const Config& config) {
+std::vector<std::string> build_system_resolver_reload_args(const Config& config) {
     if (!config.dns.has_value() || !config.dns->system_resolver.has_value()) {
         return {};
     }
@@ -15,7 +14,7 @@ std::string build_system_resolver_reload_command(const Config& config) {
         return {};
     }
 
-    return hook + " reload";
+    return {hook, "reload"};
 }
 
 bool execute_system_resolver_reload_hook(
@@ -23,27 +22,26 @@ bool execute_system_resolver_reload_hook(
     const HookCommandExecutor& executor,
     std::string& command,
     int& exit_code) {
-    command = build_system_resolver_reload_command(config);
-    if (command.empty()) {
+    const auto args = build_system_resolver_reload_args(config);
+    if (args.empty()) {
+        command.clear();
         exit_code = 0;
         return true;
     }
 
-    exit_code = executor(command);
+    // Build command string for logging
+    command.clear();
+    for (size_t i = 0; i < args.size(); ++i) {
+        if (i > 0) command += ' ';
+        command += args[i];
+    }
+
+    exit_code = executor(args);
     return exit_code == 0;
 }
 
-int default_hook_command_executor(const std::string& command) {
-    const int status = std::system(command.c_str());
-    if (status == -1) {
-        return -1;
-    }
-
-    if (WIFEXITED(status)) {
-        return WEXITSTATUS(status);
-    }
-
-    return status;
+int default_hook_command_executor(const std::vector<std::string>& args) {
+    return safe_exec(args);
 }
 
 } // namespace keen_pbr3

--- a/src/daemon/system_resolver_hook.hpp
+++ b/src/daemon/system_resolver_hook.hpp
@@ -2,14 +2,15 @@
 
 #include <functional>
 #include <string>
+#include <vector>
 
 #include "../config/config.hpp"
 
 namespace keen_pbr3 {
 
-using HookCommandExecutor = std::function<int(const std::string& command)>;
+using HookCommandExecutor = std::function<int(const std::vector<std::string>& args)>;
 
-std::string build_system_resolver_reload_command(const Config& config);
+std::vector<std::string> build_system_resolver_reload_args(const Config& config);
 
 bool execute_system_resolver_reload_hook(
     const Config& config,
@@ -17,6 +18,6 @@ bool execute_system_resolver_reload_hook(
     std::string& command,
     int& exit_code);
 
-int default_hook_command_executor(const std::string& command);
+int default_hook_command_executor(const std::vector<std::string>& args);
 
 } // namespace keen_pbr3

--- a/src/firewall/iptables.cpp
+++ b/src/firewall/iptables.cpp
@@ -2,9 +2,9 @@
 #include "ipset_restore_pipe.hpp"
 #include "../log/logger.hpp"
 #include "../util/format_compat.hpp"
+#include "../util/safe_exec.hpp"
 
 #include <cstdio>
-#include <cstdlib>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
@@ -313,8 +313,7 @@ FirewallBackend IptablesFirewall::backend() const {
 
 std::optional<bool> IptablesFirewall::test_ip_in_set(const std::string& set_name,
                                                        const std::string& ip) const {
-    std::string cmd = "ipset test " + set_name + " " + ip + " >/dev/null 2>&1";
-    int exit_code = WEXITSTATUS(std::system(cmd.c_str()));
+    int exit_code = safe_exec({"ipset", "test", set_name, ip}, /*suppress_output=*/true);
     if (exit_code == 127) return std::nullopt; // ipset not installed
     return exit_code == 0;
 }

--- a/src/firewall/nftables.cpp
+++ b/src/firewall/nftables.cpp
@@ -2,9 +2,9 @@
 #include "nft_batch_pipe.hpp"
 #include "../log/logger.hpp"
 #include "../util/format_compat.hpp"
+#include "../util/safe_exec.hpp"
 
 #include <cstdio>
-#include <cstdlib>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
@@ -382,9 +382,8 @@ FirewallBackend NftablesFirewall::backend() const {
 
 std::optional<bool> NftablesFirewall::test_ip_in_set(const std::string& set_name,
                                                        const std::string& ip) const {
-    std::string cmd = "nft get element inet " + std::string(TABLE_NAME) +
-                      " " + set_name + " { " + ip + " } >/dev/null 2>&1";
-    int exit_code = WEXITSTATUS(std::system(cmd.c_str()));
+    int exit_code = safe_exec({"nft", "get", "element", "inet", std::string(TABLE_NAME),
+                               set_name, "{", ip, "}"}, /*suppress_output=*/true);
     if (exit_code == 127) return std::nullopt; // nft not installed
     return exit_code == 0;
 }

--- a/src/util/safe_exec.hpp
+++ b/src/util/safe_exec.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <fcntl.h>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+namespace keen_pbr3 {
+
+// Execute a command with arguments directly via fork()+execvp(), bypassing
+// the shell entirely. This prevents shell injection attacks.
+// Returns the process exit code (0-255), or -1 on fork/exec failure.
+inline int safe_exec(const std::vector<std::string>& args, bool suppress_output = false) {
+    if (args.empty()) return -1;
+
+    std::vector<const char*> argv;
+    argv.reserve(args.size() + 1);
+    for (const auto& arg : args) {
+        argv.push_back(arg.c_str());
+    }
+    argv.push_back(nullptr);
+
+    const pid_t pid = fork();
+    if (pid == -1) return -1;
+
+    if (pid == 0) {
+        // Child process
+        if (suppress_output) {
+            const int devnull = open("/dev/null", O_WRONLY);
+            if (devnull >= 0) {
+                dup2(devnull, STDOUT_FILENO);
+                dup2(devnull, STDERR_FILENO);
+                close(devnull);
+            }
+        }
+        execvp(argv[0], const_cast<char* const*>(argv.data()));
+        _exit(127); // execvp failed
+    }
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) == -1) return -1;
+    if (WIFEXITED(status)) return WEXITSTATUS(status);
+    return -1;
+}
+
+} // namespace keen_pbr3

--- a/tests/test_system_resolver_hook.cpp
+++ b/tests/test_system_resolver_hook.cpp
@@ -4,18 +4,21 @@
 
 namespace keen_pbr3 {
 
-TEST_CASE("build_system_resolver_reload_command: empty when resolver config absent") {
+TEST_CASE("build_system_resolver_reload_args: empty when resolver config absent") {
     Config cfg;
-    CHECK(build_system_resolver_reload_command(cfg).empty());
+    CHECK(build_system_resolver_reload_args(cfg).empty());
 }
 
-TEST_CASE("build_system_resolver_reload_command: uses '<hook> reload'") {
+TEST_CASE("build_system_resolver_reload_args: returns hook and reload as separate args") {
     Config cfg;
     cfg.dns = DnsConfig{};
     cfg.dns->system_resolver = api::SystemResolver{};
     cfg.dns->system_resolver->hook = "/usr/local/bin/resolver-hook";
 
-    CHECK(build_system_resolver_reload_command(cfg) == "/usr/local/bin/resolver-hook reload");
+    const auto args = build_system_resolver_reload_args(cfg);
+    REQUIRE(args.size() == 2);
+    CHECK(args[0] == "/usr/local/bin/resolver-hook");
+    CHECK(args[1] == "reload");
 }
 
 TEST_CASE("execute_system_resolver_reload_hook: succeeds for zero exit code") {
@@ -24,14 +27,14 @@ TEST_CASE("execute_system_resolver_reload_hook: succeeds for zero exit code") {
     cfg.dns->system_resolver = api::SystemResolver{};
     cfg.dns->system_resolver->hook = "resolver-hook";
 
-    std::string observed_command;
+    std::vector<std::string> observed_args;
     std::string command;
     int exit_code = -1;
 
     const bool ok = execute_system_resolver_reload_hook(
         cfg,
-        [&observed_command](const std::string& cmd) {
-            observed_command = cmd;
+        [&observed_args](const std::vector<std::string>& args) {
+            observed_args = args;
             return 0;
         },
         command,
@@ -39,7 +42,9 @@ TEST_CASE("execute_system_resolver_reload_hook: succeeds for zero exit code") {
 
     CHECK(ok);
     CHECK(command == "resolver-hook reload");
-    CHECK(observed_command == "resolver-hook reload");
+    REQUIRE(observed_args.size() == 2);
+    CHECK(observed_args[0] == "resolver-hook");
+    CHECK(observed_args[1] == "reload");
     CHECK(exit_code == 0);
 }
 
@@ -54,7 +59,7 @@ TEST_CASE("execute_system_resolver_reload_hook: fails but remains non-throwing")
 
     const bool ok = execute_system_resolver_reload_hook(
         cfg,
-        [](const std::string&) {
+        [](const std::vector<std::string>&) {
             return 17;
         },
         command,


### PR DESCRIPTION
## Summary

- **Adds `src/util/safe_exec.hpp`**: A header-only `fork()`+`execvp()` utility that executes commands with an argument vector, bypassing the shell entirely to prevent injection attacks.
- **Fixes `system_resolver_hook.cpp`**: The `dns.system_resolver.hook` config value was concatenated with `" reload"` and passed to `std::system()`. Since the REST API allows writing config via `POST /api/config/save`, this was remotely exploitable. Now uses `execvp()` with `{hook, "reload"}` as separate args.
- **Fixes `iptables.cpp` and `nftables.cpp` `test_ip_in_set()`**: IP and set_name were concatenated directly into shell commands (`ipset test` / `nft get element`). Now uses `execvp()` with proper argument arrays.

## Test plan

- [x] Project builds cleanly (`cmake --build build`)
- [x] All 277 unit tests pass
- [x] No `std::system()` calls remain in the three fixed files
- [ ] Manual verification: confirm hook execution still works with a valid hook path
- [ ] Manual verification: confirm `test_ip_in_set()` works for both iptables and nftables backends

https://claude.ai/code/session_01DGb87H2swMYH1A3w7LVhNS