### PR TITLE
Fix urltest switching when current outbound is within tolerance

### DIFF
--- a/src/routing/urltest_manager.cpp
+++ b/src/routing/urltest_manager.cpp
@@ -174,6 +174,24 @@ std::string UrltestManager::select_outbound(const std::string& tag) {
             continue;
         }
 
+        uint32_t tolerance = static_cast<uint32_t>(ut.tolerance_ms.value_or(100));
+
+        // Prefer the currently selected outbound if it belongs to this group
+        // and is still within tolerance — avoids unnecessary switching
+        if (!state.selected_outbound.empty()) {
+            auto incumbent_in_group = std::find(group.outbounds.begin(), group.outbounds.end(), state.selected_outbound);
+            if (incumbent_in_group != group.outbounds.end()) {
+                auto cb_it = state.circuit_breakers.find(state.selected_outbound);
+                if (cb_it != state.circuit_breakers.end() && cb_it->second.state(state.selected_outbound) != CircuitState::open) {
+                    auto res_it = state.last_results.find(state.selected_outbound);
+                    if (res_it != state.last_results.end() && res_it->second.success &&
+                        res_it->second.latency_ms <= min_latency + tolerance) {
+                        return state.selected_outbound;
+                    }
+                }
+            }
+        }
+
         // Find first outbound within tolerance of min_latency
         for (const auto& child_tag : group.outbounds) {
             auto cb_it = state.circuit_breakers.find(child_tag);
@@ -185,7 +203,7 @@ std::string UrltestManager::select_outbound(const std::string& tag) {
             auto res_it = state.last_results.find(child_tag);
             if (res_it == state.last_results.end() || !res_it->second.success) continue;
 
-            if (res_it->second.latency_ms <= min_latency + static_cast<uint32_t>(ut.tolerance_ms.value_or(100))) {
+            if (res_it->second.latency_ms <= min_latency + tolerance) {
                 return child_tag;
             }
         }


### PR DESCRIPTION
## Summary

- `select_outbound()` always picked the first outbound in group order within tolerance of the minimum latency, with no preference for the currently active outbound
- This caused unnecessary switches even when the latency difference between the current and best outbound was below the configured `tolerance_ms` threshold
- Now the incumbent outbound is preferred if it belongs to the current group, its circuit breaker allows it, and its latency is within `min_latency + tolerance_ms`

**Example before fix:** tolerance=100ms, A is active at 800ms, B at 750ms. Despite 800-750=50 < 100, the code switched to B because B came first in group order.

**After fix:** A is kept because it's within tolerance of the minimum.

## Test plan

- [ ] Verify build compiles successfully
- [ ] Scenario: current outbound within tolerance of min → no switch
- [ ] Scenario: current outbound outside tolerance of min → switch to best
- [ ] Scenario: current outbound circuit breaker open → switch normally
- [ ] Scenario: first selection (no incumbent) → picks first within tolerance as before
- [ ] Scenario: current outbound in different group than the best group → respects group priority

https://claude.ai/code/session_0191ekJUC2V15BVqi22uBskF