### PR TITLE
Harden firewall verifier: scope nft query, cache parsed state, cap command output, and switch to argv runner

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -222,6 +222,12 @@ components:
           description: Directory for cached list data.
           default: "/var/cache/keen-pbr"
           example: "/var/cache/keen-pbr"
+        firewall_verify_max_bytes:
+          type: integer
+          minimum: 0
+          description: Max stdout bytes captured per firewall verification command (0 = unlimited).
+          default: 262144
+          example: 262144
         strict_enforcement:
           type: boolean
           description: >
@@ -636,6 +642,7 @@ components:
         daemon:
           pid_file: "/var/run/keen-pbr.pid"
           cache_dir: "/var/cache/keen-pbr"
+          firewall_verify_max_bytes: 262144
           strict_enforcement: true
         api:
           enabled: true

--- a/src/api/generated/api_types.hpp
+++ b/src/api/generated/api_types.hpp
@@ -116,6 +116,7 @@ namespace api {
 
     struct Daemon {
         std::optional<std::string> cache_dir;
+        std::optional<int64_t> firewall_verify_max_bytes;
         std::optional<std::string> pid_file;
         std::optional<bool> strict_enforcement;
     };
@@ -685,6 +686,7 @@ namespace api {
 
     inline void from_json(const json & j, Daemon& x) {
         x.cache_dir = get_stack_optional<std::string>(j, "cache_dir");
+        x.firewall_verify_max_bytes = get_stack_optional<int64_t>(j, "firewall_verify_max_bytes");
         x.pid_file = get_stack_optional<std::string>(j, "pid_file");
         x.strict_enforcement = get_stack_optional<bool>(j, "strict_enforcement");
     }
@@ -692,6 +694,7 @@ namespace api {
     inline void to_json(json & j, const Daemon & x) {
         j = json::object();
         j["cache_dir"] = x.cache_dir;
+        j["firewall_verify_max_bytes"] = x.firewall_verify_max_bytes;
         j["pid_file"] = x.pid_file;
         j["strict_enforcement"] = x.strict_enforcement;
     }

--- a/src/cmd/status.cpp
+++ b/src/cmd/status.cpp
@@ -2,6 +2,7 @@
 
 #include "../config/routing_state.hpp"
 #include "../firewall/firewall.hpp"
+#include "../firewall/firewall_verifier.hpp"
 #include "../health/routing_health_checker.hpp"
 #include "../routing/firewall_state.hpp"
 #include "../routing/netlink.hpp"
@@ -481,6 +482,9 @@ void print_overall_summary(const RoutingHealthReport& report,
 } // namespace
 
 int run_status_command(const Config& config, const std::string& config_path) {
+    const int64_t verify_max_bytes = config.daemon.value_or(DaemonConfig{})
+        .firewall_verify_max_bytes.value_or(static_cast<int64_t>(DEFAULT_FIREWALL_VERIFY_CAPTURE_MAX_BYTES));
+    set_firewall_verifier_capture_max_bytes(static_cast<size_t>(verify_max_bytes));
     auto marks = allocate_outbound_marks(config.fwmark.value_or(FwmarkConfig{}),
                                          config.outbounds.value_or(std::vector<Outbound>{}));
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -273,6 +273,9 @@ Config parse_config(const std::string& json_str) {
         parsed_json, "fwmark", "mask", "fwmark.mask", issues);
     validate_optional_integer_field(
         parsed_json, "iproute", "table_start", "iproute.table_start", issues);
+    validate_optional_integer_field(
+        parsed_json, "daemon", "firewall_verify_max_bytes",
+        "daemon.firewall_verify_max_bytes", issues);
     validate_route_rule_specs(parsed_json, issues);
 
     if (!issues.empty()) {
@@ -292,6 +295,12 @@ Config parse_config(const std::string& json_str) {
 
 void validate_config(const Config& cfg) {
     std::vector<ConfigValidationIssue> issues;
+
+    if (cfg.daemon && cfg.daemon->firewall_verify_max_bytes.has_value() &&
+        *cfg.daemon->firewall_verify_max_bytes < 0) {
+        add_issue(issues, "daemon.firewall_verify_max_bytes",
+                  "daemon.firewall_verify_max_bytes must be >= 0");
+    }
 
     if (cfg.lists_autoupdate) {
         const bool enabled = cfg.lists_autoupdate->enabled.value_or(false);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -27,6 +27,7 @@
 #include "../dns/dns_server.hpp"
 #include "../dns/dns_txt_client.hpp"
 #include "../firewall/firewall.hpp"
+#include "../firewall/firewall_verifier.hpp"
 #include "../lists/list_entry_visitor.hpp"
 #include "../lists/list_set_usage.hpp"
 #include "../lists/list_streamer.hpp"
@@ -97,6 +98,10 @@ Daemon::Daemon(Config config,
 
     setup_signals();
     setup_control_channel();
+
+    const int64_t verify_max_bytes = config_.daemon.value_or(DaemonConfig{})
+        .firewall_verify_max_bytes.value_or(static_cast<int64_t>(DEFAULT_FIREWALL_VERIFY_CAPTURE_MAX_BYTES));
+    set_firewall_verifier_capture_max_bytes(static_cast<size_t>(verify_max_bytes));
 
     // Set outbound marks in firewall state
     firewall_state_.set_outbound_marks(outbound_marks_);

--- a/src/firewall/firewall_verifier.cpp
+++ b/src/firewall/firewall_verifier.cpp
@@ -3,12 +3,27 @@
 #include "nftables_verifier.hpp"
 #include "../util/safe_exec.hpp"
 
+#include <atomic>
 
 namespace keen_pbr3 {
 
+namespace {
+std::atomic_size_t g_firewall_verify_capture_max_bytes{DEFAULT_FIREWALL_VERIFY_CAPTURE_MAX_BYTES};
+}
+
+
+void set_firewall_verifier_capture_max_bytes(size_t max_bytes) {
+    g_firewall_verify_capture_max_bytes.store(max_bytes, std::memory_order_relaxed);
+}
+
+size_t get_firewall_verifier_capture_max_bytes() {
+    return g_firewall_verify_capture_max_bytes.load(std::memory_order_relaxed);
+}
+
 std::string run_command_capture(const std::vector<std::string>& args) {
     if (args.empty()) return {};
-    return safe_exec_capture(args, /*suppress_stderr=*/true, /*max_bytes=*/262144);
+    return safe_exec_capture(args, /*suppress_stderr=*/true,
+                             /*max_bytes=*/get_firewall_verifier_capture_max_bytes());
 }
 
 std::unique_ptr<FirewallVerifier> create_firewall_verifier(

--- a/src/firewall/firewall_verifier.cpp
+++ b/src/firewall/firewall_verifier.cpp
@@ -3,26 +3,12 @@
 #include "nftables_verifier.hpp"
 #include "../util/safe_exec.hpp"
 
-#include <sstream>
-#include <string>
 
 namespace keen_pbr3 {
 
-// Split a command string into args for safe_exec_capture.
-static std::vector<std::string> split_command(const std::string& cmd) {
-    std::vector<std::string> args;
-    std::istringstream iss(cmd);
-    std::string token;
-    while (iss >> token) {
-        args.push_back(token);
-    }
-    return args;
-}
-
-std::string run_command_capture(const std::string& cmd) {
-    auto args = split_command(cmd);
+std::string run_command_capture(const std::vector<std::string>& args) {
     if (args.empty()) return {};
-    return safe_exec_capture(args, /*suppress_stderr=*/true);
+    return safe_exec_capture(args, /*suppress_stderr=*/true, /*max_bytes=*/262144);
 }
 
 std::unique_ptr<FirewallVerifier> create_firewall_verifier(

--- a/src/firewall/firewall_verifier.hpp
+++ b/src/firewall/firewall_verifier.hpp
@@ -13,11 +13,11 @@ namespace keen_pbr3 {
 
 // Type alias for a function that runs a command and returns its stdout output.
 // Default implementation uses fork()+execvp(). Can be injected for testing.
-using CommandRunner = std::function<std::string(const std::string& cmd)>;
+using CommandRunner = std::function<std::string(const std::vector<std::string>& args)>;
 
-// Run a shell command and capture its stdout output.
+// Run a command and capture its stdout output.
 // Returns the captured output, or empty string on error.
-std::string run_command_capture(const std::string& cmd);
+std::string run_command_capture(const std::vector<std::string>& args);
 
 // Abstract interface for verifying live firewall state against expected configuration.
 class FirewallVerifier {

--- a/src/firewall/firewall_verifier.hpp
+++ b/src/firewall/firewall_verifier.hpp
@@ -17,6 +17,11 @@ using CommandRunner = std::function<std::string(const std::vector<std::string>& 
 
 // Run a command and capture its stdout output.
 // Returns the captured output, or empty string on error.
+constexpr size_t DEFAULT_FIREWALL_VERIFY_CAPTURE_MAX_BYTES = 262144;
+
+void set_firewall_verifier_capture_max_bytes(size_t max_bytes);
+size_t get_firewall_verifier_capture_max_bytes();
+
 std::string run_command_capture(const std::vector<std::string>& args);
 
 // Abstract interface for verifying live firewall state against expected configuration.

--- a/src/firewall/iptables_verifier.cpp
+++ b/src/firewall/iptables_verifier.cpp
@@ -89,8 +89,8 @@ IptablesFirewallVerifier::IptablesFirewallVerifier(CommandRunner runner)
     : runner_(std::move(runner)) {}
 
 FirewallChainCheck IptablesFirewallVerifier::verify_chain() {
-    const std::string v4_out = runner_("iptables-save -t mangle");
-    const std::string v6_out = runner_("ip6tables-save -t mangle");
+    const std::string v4_out = runner_({"iptables-save", "-t", "mangle"});
+    const std::string v6_out = runner_({"ip6tables-save", "-t", "mangle"});
 
     const auto v4 = parse_iptables_save(v4_out, false);
     const auto v6 = parse_iptables_save(v6_out, true);
@@ -115,8 +115,8 @@ FirewallChainCheck IptablesFirewallVerifier::verify_chain() {
 
 std::vector<FirewallRuleCheck> IptablesFirewallVerifier::verify_rules(
     const std::vector<RuleState>& expected) {
-    const std::string v4_out = runner_("iptables-save -t mangle");
-    const std::string v6_out = runner_("ip6tables-save -t mangle");
+    const std::string v4_out = runner_({"iptables-save", "-t", "mangle"});
+    const std::string v6_out = runner_({"ip6tables-save", "-t", "mangle"});
 
     const auto v4 = parse_iptables_save(v4_out, false);
     const auto v6 = parse_iptables_save(v6_out, true);

--- a/src/firewall/nftables_verifier.cpp
+++ b/src/firewall/nftables_verifier.cpp
@@ -166,9 +166,16 @@ ParsedNftablesState parse_nft_json(const std::string& json_output) {
 NftablesFirewallVerifier::NftablesFirewallVerifier(CommandRunner runner)
     : runner_(std::move(runner)) {}
 
+const ParsedNftablesState& NftablesFirewallVerifier::get_state() const {
+    if (!cached_state_.has_value()) {
+        const std::string nft_out = runner_({"nft", "-j", "list", "table", "inet", TABLE_NAME});
+        cached_state_ = parse_nft_json(nft_out);
+    }
+    return *cached_state_;
+}
+
 FirewallChainCheck NftablesFirewallVerifier::verify_chain() {
-    const std::string nft_out = runner_("nft -j list ruleset");
-    const auto state = parse_nft_json(nft_out);
+    const auto& state = get_state();
 
     FirewallChainCheck result;
     result.chain_present = state.has_prerouting_chain;
@@ -191,8 +198,7 @@ FirewallChainCheck NftablesFirewallVerifier::verify_chain() {
 
 std::vector<FirewallRuleCheck> NftablesFirewallVerifier::verify_rules(
     const std::vector<RuleState>& expected) {
-    const std::string nft_out = runner_("nft -j list ruleset");
-    const auto state = parse_nft_json(nft_out);
+    const auto& state = get_state();
 
     // Build lookup: set_name -> ParsedNftRule
     std::map<std::string, ParsedNftRule> rule_map;

--- a/src/firewall/nftables_verifier.hpp
+++ b/src/firewall/nftables_verifier.hpp
@@ -4,12 +4,13 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
 namespace keen_pbr3 {
 
-// A single parsed rule from nft -j list ruleset output (within KeenPbrTable/prerouting chain).
+// A single parsed rule from nft -j list table inet KeenPbrTable output (within KeenPbrTable/prerouting chain).
 struct ParsedNftRule {
     std::string set_name;  // Named set referenced in the match expression (without '@' prefix)
     bool is_mark{false};   // true if rule has a mangle/meta mark action
@@ -18,7 +19,7 @@ struct ParsedNftRule {
     bool ipv6{false};      // true if the payload protocol is ip6
 };
 
-// Parsed state of the KeenPbrTable from nft -j list ruleset output.
+// Parsed state of the KeenPbrTable from nft -j list table inet KeenPbrTable output.
 struct ParsedNftablesState {
     bool has_table{false};              // inet KeenPbrTable table was found
     bool has_prerouting_chain{false};   // prerouting chain in KeenPbrTable was found
@@ -26,7 +27,7 @@ struct ParsedNftablesState {
     std::vector<ParsedNftRule> rules;   // rules in the prerouting chain
 };
 
-// Parse the stdout of `nft -j list ruleset`.
+// Parse the stdout of `nft -j list table inet KeenPbrTable`.
 // Returns the parsed state of KeenPbrTable.
 // On any JSON parse error or invalid input, returns a default (empty) state.
 ParsedNftablesState parse_nft_json(const std::string& json_output);
@@ -47,7 +48,10 @@ private:
     static constexpr const char* TABLE_NAME = "KeenPbrTable";
     static constexpr const char* CHAIN_NAME = "prerouting";
 
+    const ParsedNftablesState& get_state() const;
+
     CommandRunner runner_;
+    mutable std::optional<ParsedNftablesState> cached_state_;
 };
 
 // Factory function called from firewall_verifier.cpp

--- a/src/util/safe_exec.hpp
+++ b/src/util/safe_exec.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cerrno>
+#include <signal.h>
 #include <fcntl.h>
 #include <string>
 #include <sys/wait.h>
@@ -101,7 +102,8 @@ inline int safe_exec_pipe_stdin(const std::vector<std::string>& args,
 // Execute a command with arguments and capture its stdout output.
 // Returns the captured output string. Returns empty string on failure.
 inline std::string safe_exec_capture(const std::vector<std::string>& args,
-                                     bool suppress_stderr = false) {
+                                     bool suppress_stderr = false,
+                                     size_t max_bytes = 0) {
     if (args.empty()) return {};
 
     std::vector<const char*> argv;
@@ -145,6 +147,13 @@ inline std::string safe_exec_capture(const std::vector<std::string>& args,
         const ssize_t n = read(pipefd[0], buf, sizeof(buf));
         if (n > 0) {
             result.append(buf, static_cast<size_t>(n));
+            if (max_bytes > 0 && result.size() > max_bytes) {
+                close(pipefd[0]);
+                kill(pid, SIGTERM);
+                int status = 0;
+                waitpid(pid, &status, 0);
+                return {};
+            }
         } else if (n == 0) {
             break;
         } else {

--- a/tests/test_config_validation.cpp
+++ b/tests/test_config_validation.cpp
@@ -459,3 +459,20 @@ TEST_CASE("config parsing returns all collected validation errors") {
         CHECK(saw_list_error);
     }
 }
+
+TEST_CASE("daemon.firewall_verify_max_bytes: accepts positive value") {
+    auto cfg = parse_test_config(R"({"daemon":{"firewall_verify_max_bytes":131072}})");
+    REQUIRE(cfg.daemon.has_value());
+    REQUIRE(cfg.daemon->firewall_verify_max_bytes.has_value());
+    CHECK(*cfg.daemon->firewall_verify_max_bytes == 131072);
+}
+
+TEST_CASE("daemon.firewall_verify_max_bytes: rejects non-integer value") {
+    const auto issues = parse_issues(R"({"daemon":{"firewall_verify_max_bytes":"131072"}})");
+    REQUIRE(issues.size() == 1);
+    CHECK(issues[0].path == "daemon.firewall_verify_max_bytes");
+}
+
+TEST_CASE("daemon.firewall_verify_max_bytes: rejects negative value") {
+    CHECK_THROWS_AS(parse_test_config(R"({"daemon":{"firewall_verify_max_bytes":-1}})"), ConfigError);
+}

--- a/tests/test_firewall_verifier.cpp
+++ b/tests/test_firewall_verifier.cpp
@@ -250,7 +250,7 @@ TEST_CASE("IptablesFirewallVerifier::verify_rules: mark rule ok") {
         "-A PREROUTING -j KeenPbrTable\n"
         "-A KeenPbrTable -m set --match-set set1 dst -j MARK --set-mark 65536\n";
 
-    auto runner = [&canned](const std::string&) -> std::string { return canned; };
+    auto runner = [&canned](const std::vector<std::string>&) -> std::string { return canned; };
     IptablesFirewallVerifier verifier(runner);
 
     RuleState rs;
@@ -274,7 +274,7 @@ TEST_CASE("IptablesFirewallVerifier::verify_rules: mark rule missing") {
         ":KeenPbrTable - [0:0]\n"
         "-A PREROUTING -j KeenPbrTable\n";
 
-    auto runner = [&canned](const std::string&) -> std::string { return canned; };
+    auto runner = [&canned](const std::vector<std::string>&) -> std::string { return canned; };
     IptablesFirewallVerifier verifier(runner);
 
     RuleState rs;
@@ -293,7 +293,7 @@ TEST_CASE("IptablesFirewallVerifier::verify_rules: fwmark mismatch") {
         ":KeenPbrTable - [0:0]\n"
         "-A KeenPbrTable -m set --match-set set1 dst -j MARK --set-mark 65536\n";
 
-    auto runner = [&canned](const std::string&) -> std::string { return canned; };
+    auto runner = [&canned](const std::vector<std::string>&) -> std::string { return canned; };
     IptablesFirewallVerifier verifier(runner);
 
     RuleState rs;
@@ -314,7 +314,7 @@ TEST_CASE("IptablesFirewallVerifier::verify_rules: drop rule ok") {
         ":KeenPbrTable - [0:0]\n"
         "-A KeenPbrTable -m set --match-set blacklist dst -j DROP\n";
 
-    auto runner = [&canned](const std::string&) -> std::string { return canned; };
+    auto runner = [&canned](const std::vector<std::string>&) -> std::string { return canned; };
     IptablesFirewallVerifier verifier(runner);
 
     RuleState rs;
@@ -329,7 +329,7 @@ TEST_CASE("IptablesFirewallVerifier::verify_rules: drop rule ok") {
 
 TEST_CASE("IptablesFirewallVerifier::verify_rules: skip rule produces no check") {
     const std::string canned = "";
-    auto runner = [&canned](const std::string&) -> std::string { return canned; };
+    auto runner = [&canned](const std::vector<std::string>&) -> std::string { return canned; };
     IptablesFirewallVerifier verifier(runner);
 
     RuleState rs;
@@ -363,7 +363,7 @@ TEST_CASE("NftablesFirewallVerifier::verify_rules: mark rule ok") {
         ]
     })";
 
-    auto runner = [&canned](const std::string&) -> std::string { return canned; };
+    auto runner = [&canned](const std::vector<std::string>&) -> std::string { return canned; };
     NftablesFirewallVerifier verifier(runner);
 
     RuleState rs;
@@ -388,7 +388,7 @@ TEST_CASE("NftablesFirewallVerifier::verify_rules: mark rule missing") {
         ]
     })";
 
-    auto runner = [&canned](const std::string&) -> std::string { return canned; };
+    auto runner = [&canned](const std::vector<std::string>&) -> std::string { return canned; };
     NftablesFirewallVerifier verifier(runner);
 
     RuleState rs;
@@ -420,7 +420,7 @@ TEST_CASE("NftablesFirewallVerifier::verify_rules: drop rule ok") {
         ]
     })";
 
-    auto runner = [&canned](const std::string&) -> std::string { return canned; };
+    auto runner = [&canned](const std::vector<std::string>&) -> std::string { return canned; };
     NftablesFirewallVerifier verifier(runner);
 
     RuleState rs;
@@ -451,7 +451,7 @@ TEST_CASE("NftablesFirewallVerifier::verify_rules: fwmark mismatch") {
         ]
     })";
 
-    auto runner = [&canned](const std::string&) -> std::string { return canned; };
+    auto runner = [&canned](const std::vector<std::string>&) -> std::string { return canned; };
     NftablesFirewallVerifier verifier(runner);
 
     RuleState rs;


### PR DESCRIPTION
### Motivation
- Prevent OOMs when verifying nftables by avoiding reading the entire ruleset and by bounding subprocess output. 
- Reduce duplicate subprocess invocations by sharing parsed nft state between `verify_chain()` and `verify_rules()`. 
- Simplify and harden command execution paths to avoid shell splitting and enable size-capped captures for defense-in-depth.

### Description
- Changed nft invocation to query only the KeenPbr table via `nft -j list table inet KeenPbrTable` and updated related doc comments. 
- Added a lazy cached accessor `NftablesFirewallVerifier::get_state()` with a `mutable std::optional<ParsedNftablesState> cached_state_` so `verify_chain()` and `verify_rules()` share one parsed state per verifier. 
- Switched the `CommandRunner` API from `std::function<std::string(const std::string&)>` to `std::function<std::string(const std::vector<std::string>&)>` and updated callers to pass argv vectors directly (removed string splitting). 
- Added an optional `max_bytes` parameter to `safe_exec_capture()` and enforced a default 256 KiB cap in `run_command_capture`, where overflowing the cap closes the pipe, sends `SIGTERM` to the child, `waitpid`s it, and returns an empty string. 
- Updated iptables/nftables verifier invocations to use argv vectors and adjusted tests in `tests/test_firewall_verifier.cpp` to inject runners with the new signature.

### Testing
- Ran `make` from the repository root; CMake configuration failed in this environment due to a missing system dependency (`libnl-3.0`), so the build/test step did not complete. 
- Unit test sources were updated to match the new `CommandRunner` signature and should run normally when the environment has required system packages installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c56ef5ac6c832abcd4c423f8539742)