### PR TITLE
Cache iptables state to avoid redundant command executions

### DIFF
--- a/src/firewall/iptables_verifier.cpp
+++ b/src/firewall/iptables_verifier.cpp
@@ -88,12 +88,18 @@ ParsedIptablesState parse_iptables_save(const std::string& output, bool /*ipv6*/
 IptablesFirewallVerifier::IptablesFirewallVerifier(CommandRunner runner)
     : runner_(std::move(runner)) {}
 
-FirewallChainCheck IptablesFirewallVerifier::verify_chain() {
-    const std::string v4_out = runner_({"iptables-save", "-t", "mangle"});
-    const std::string v6_out = runner_({"ip6tables-save", "-t", "mangle"});
+const IptablesFirewallVerifier::CachedState& IptablesFirewallVerifier::get_state() const {
+    if (!cached_state_.has_value()) {
+        CachedState state;
+        state.v4 = parse_iptables_save(runner_({"iptables-save", "-t", "mangle"}), false);
+        state.v6 = parse_iptables_save(runner_({"ip6tables-save", "-t", "mangle"}), true);
+        cached_state_ = std::move(state);
+    }
+    return *cached_state_;
+}
 
-    const auto v4 = parse_iptables_save(v4_out, false);
-    const auto v6 = parse_iptables_save(v6_out, true);
+FirewallChainCheck IptablesFirewallVerifier::verify_chain() {
+    const auto& [v4, v6] = get_state();
 
     FirewallChainCheck result;
     result.chain_present = v4.has_keen_pbr_chain || v6.has_keen_pbr_chain;
@@ -115,11 +121,7 @@ FirewallChainCheck IptablesFirewallVerifier::verify_chain() {
 
 std::vector<FirewallRuleCheck> IptablesFirewallVerifier::verify_rules(
     const std::vector<RuleState>& expected) {
-    const std::string v4_out = runner_({"iptables-save", "-t", "mangle"});
-    const std::string v6_out = runner_({"ip6tables-save", "-t", "mangle"});
-
-    const auto v4 = parse_iptables_save(v4_out, false);
-    const auto v6 = parse_iptables_save(v6_out, true);
+    const auto& [v4, v6] = get_state();
 
     // Build a combined lookup: set_name -> ParsedIptablesRule
     // v4 entries are inserted first; v6 entries only added if set_name not already present

--- a/src/firewall/iptables_verifier.hpp
+++ b/src/firewall/iptables_verifier.hpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -43,7 +44,15 @@ public:
 private:
     static constexpr const char* CHAIN_NAME = "KeenPbrTable";
 
+    struct CachedState {
+        ParsedIptablesState v4;
+        ParsedIptablesState v6;
+    };
+
+    const CachedState& get_state() const;
+
     CommandRunner runner_;
+    mutable std::optional<CachedState> cached_state_;
 };
 
 // Factory function called from firewall_verifier.cpp


### PR DESCRIPTION
## Summary
Refactored `IptablesFirewallVerifier` to cache the parsed iptables state, eliminating redundant executions of `iptables-save` and `ip6tables-save` commands when both `verify_chain()` and `verify_rules()` are called.

## Key Changes
- Added `CachedState` struct to hold both IPv4 and IPv6 parsed iptables states
- Introduced `get_state()` private method that lazily initializes and caches the iptables state on first access
- Refactored `verify_chain()` and `verify_rules()` to use the cached state instead of independently running the save commands
- Added `mutable std::optional<CachedState>` member variable to store the cached state
- Added `#include <optional>` header dependency

## Implementation Details
- The cache is implemented using `std::optional` to defer initialization until first use
- The `get_state()` method is marked `const` with a `mutable` cache member to allow caching within const methods
- Both `verify_chain()` and `verify_rules()` now use structured bindings to extract v4 and v6 states from the cache
- This optimization is particularly beneficial when the verifier is used to perform multiple verification checks in sequence

https://claude.ai/code/session_01EDeDtHn6r7cR5zXd5r9hoh