### PR TITLE
Add bounds checks to ByteView index operator

### DIFF
--- a/src/util/byte_view.hpp
+++ b/src/util/byte_view.hpp
@@ -17,7 +17,12 @@ public:
     const uint8_t* data() const { return data_; }
     std::size_t size() const { return size_; }
 
-    const uint8_t& operator[](std::size_t index) const { return data_[index]; }
+    const uint8_t& operator[](std::size_t index) const {
+        if (index >= size_) {
+            throw std::out_of_range("ByteView::operator[] out of range");
+        }
+        return data_[index];
+    }
 
     const uint8_t* begin() const { return data_; }
     const uint8_t* end() const { return data_ + size_; }


### PR DESCRIPTION
### Motivation
- Prevent out-of-bounds reads from unchecked `ByteView::operator[]` usages (for example in DNS packet parsing where code mixes `packet[pos]` and `packet.subspan()`), so a missed guard cannot read past the buffer end.

### Description
- Add an explicit bounds check to `ByteView::operator[]` that throws `std::out_of_range` when `index >= size_`.
- Change implemented in `src/util/byte_view.hpp` and leaves existing `ByteView::subspan()` range validation unchanged.

### Testing
- Ran `make`, but CMake configuration failed because the required package `libnl-3.0` is not available in the environment, so the build could not be validated in this CI environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7deff1d10832aa99415095a9d4aa7)