### PR TITLE
Make MD5State::digest non‑mutating and preserve original length during finalization

### DIFF
--- a/src/crypto/md5.hpp
+++ b/src/crypto/md5.hpp
@@ -93,17 +93,18 @@ struct MD5State {
         }
     }
 
-    std::array<uint8_t, 16> digest() {
+    std::array<uint8_t, 16> finalize() {
         // Padding
         uint8_t pad[64] = {};
         pad[0] = 0x80u;
         size_t pad_len = (buf_len < 56) ? (56u - buf_len) : (120u - buf_len);
+        const uint64_t message_bits = count;
         update(pad, pad_len);
 
         // Length
         uint8_t len_bytes[8];
         for (int i = 0; i < 8; ++i)
-            len_bytes[i] = uint8_t(count >> (i * 8));
+            len_bytes[i] = uint8_t(message_bits >> (i * 8));
         update(len_bytes, 8);
 
         std::array<uint8_t, 16> result;
@@ -114,6 +115,11 @@ struct MD5State {
             result[i+12] = uint8_t(d >> (i*8));
         }
         return result;
+    }
+
+    std::array<uint8_t, 16> digest() const {
+        MD5State copy = *this;
+        return copy.finalize();
     }
 };
 


### PR DESCRIPTION
### Motivation
- Prevent internal state corruption when finalizing an MD5 state by ensuring calling `digest()` multiple times does not mutate the original `MD5State`, and ensure the appended length field reflects the original message length.

### Description
- In `src/crypto/md5.hpp` split the finalization logic into a mutating `finalize()` helper and a non‑mutating `digest() const` wrapper that copies the state and calls `finalize()`.
- Capture the original `count` into a `message_bits` local before applying padding so the 8‑byte length appended to the stream is based on the original message length, not the mutated state.
- Leave the public `md5_hex` helper unchanged so external usage remains the same.

### Testing
- Ran `make`; CMake configure failed in this environment due to a missing system dependency (`libnl-3.0`), so a full build/test could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7df2f9c84832a8325fda288304dad)