### PR TITLE
Add port_spec_util for parsing/normalizing port specs and integrate into iptables/nftables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ set(SOURCES
   src/routing/urltest_manager.cpp
   src/routing/firewall_state.cpp
   src/firewall/firewall.cpp
+  src/firewall/port_spec_util.cpp
   src/firewall/iptables.cpp
   src/firewall/nftables.cpp
   src/firewall/ipset_restore_pipe.cpp

--- a/src/firewall/iptables.cpp
+++ b/src/firewall/iptables.cpp
@@ -1,5 +1,6 @@
 #include "iptables.hpp"
 #include "ipset_restore_pipe.hpp"
+#include "port_spec_util.hpp"
 #include "../log/logger.hpp"
 #include "../util/format_compat.hpp"
 #include "../util/safe_exec.hpp"
@@ -120,21 +121,6 @@ std::string IptablesFirewall::build_ipset_create_line(const PendingSet& ps) {
     }
 }
 
-// Convert a port spec token to iptables format.
-// "443" → "443", "8000-9000" → "8000:9000" (iptables uses colon for range)
-static std::string port_token_to_ipt(const std::string& token) {
-    auto dash = token.find('-');
-    if (dash != std::string::npos) {
-        return token.substr(0, dash) + ":" + token.substr(dash + 1);
-    }
-    return token;
-}
-
-// Returns true if port_spec is a comma-separated list (contains ',').
-static bool is_port_list(const std::string& port_spec) {
-    return port_spec.find(',') != std::string::npos;
-}
-
 std::string IptablesFirewall::build_proto_port_fragment(const std::string& proto,
                                                          const std::string& src_port,
                                                          const std::string& dst_port,
@@ -153,8 +139,10 @@ std::string IptablesFirewall::build_proto_port_fragment(const std::string& proto
 
     bool has_src = !src_port.empty();
     bool has_dst = !dst_port.empty();
-    bool src_list = has_src && is_port_list(src_port);
-    bool dst_list = has_dst && is_port_list(dst_port);
+    bool src_list = has_src && classify_port_spec(src_port) == PortSpecKind::List;
+    bool dst_list = has_dst && classify_port_spec(dst_port) == PortSpecKind::List;
+    std::string normalized_src = has_src ? normalize_port_spec_for_iptables(src_port) : "";
+    std::string normalized_dst = has_dst ? normalize_port_spec_for_iptables(dst_port) : "";
 
     // Use -m multiport when: both ports present, or either is a comma list
     if (has_src || has_dst) {
@@ -162,17 +150,17 @@ std::string IptablesFirewall::build_proto_port_fragment(const std::string& proto
             // When negation differs between src and dst, emit separate -m multiport clauses
             // (iptables cannot mix negated and non-negated flags in one multiport call).
             if (has_src && has_dst && negate_src_port != negate_dst_port) {
-                frag += " -m multiport" + std::string(negate_src_port ? " !" : "") + " --sports " + src_port;
-                frag += " -m multiport" + std::string(negate_dst_port ? " !" : "") + " --dports " + dst_port;
+                frag += " -m multiport" + std::string(negate_src_port ? " !" : "") + " --sports " + normalized_src;
+                frag += " -m multiport" + std::string(negate_dst_port ? " !" : "") + " --dports " + normalized_dst;
             } else {
                 frag += " -m multiport";
-                if (has_src) frag += std::string(negate_src_port ? " !" : "") + " --sports " + src_port;
-                if (has_dst) frag += std::string(negate_dst_port ? " !" : "") + " --dports " + dst_port;
+                if (has_src) frag += std::string(negate_src_port ? " !" : "") + " --sports " + normalized_src;
+                if (has_dst) frag += std::string(negate_dst_port ? " !" : "") + " --dports " + normalized_dst;
             }
         } else {
             // Single port or range, single direction — use --sport/--dport
-            if (has_src) frag += std::string(negate_src_port ? " !" : "") + " --sport " + port_token_to_ipt(src_port);
-            if (has_dst) frag += std::string(negate_dst_port ? " !" : "") + " --dport " + port_token_to_ipt(dst_port);
+            if (has_src) frag += std::string(negate_src_port ? " !" : "") + " --sport " + normalized_src;
+            if (has_dst) frag += std::string(negate_dst_port ? " !" : "") + " --dport " + normalized_dst;
         }
     }
 

--- a/src/firewall/nftables.cpp
+++ b/src/firewall/nftables.cpp
@@ -1,5 +1,6 @@
 #include "nftables.hpp"
 #include "nft_batch_pipe.hpp"
+#include "port_spec_util.hpp"
 #include "../log/logger.hpp"
 #include "../util/format_compat.hpp"
 #include "../util/safe_exec.hpp"
@@ -122,27 +123,43 @@ std::unique_ptr<ListEntryVisitor> NftablesFirewall::create_batch_loader(
 // "8000-9000" → {"range": [8000, 9000]}
 // "80,443"    → {"set": [80, 443]}
 static nlohmann::json port_spec_to_nft_rhs(const std::string& spec) {
-    if (spec.find(',') != std::string::npos) {
+    PortSpecKind kind = classify_port_spec(spec);
+    if (kind == PortSpecKind::List) {
         nlohmann::json arr = nlohmann::json::array();
-        std::string token;
-        for (char c : spec) {
-            if (c == ',') {
-                arr.push_back(std::stoi(token));
-                token.clear();
+        for (const auto& token : split_port_spec_tokens(spec)) {
+            PortSpecKind token_kind = classify_port_spec(token);
+            if (token_kind == PortSpecKind::Range) {
+                int lo = 0;
+                int hi = 0;
+                if (!parse_port_range(token, lo, hi)) {
+                    throw std::invalid_argument(keen_pbr3::format("Invalid port token '{}' in port spec '{}'", token, spec));
+                }
+                arr.push_back({{"range", nlohmann::json::array({lo, hi})}});
             } else {
-                token += c;
+                int port = 0;
+                if (!parse_port_value(token, port)) {
+                    throw std::invalid_argument(keen_pbr3::format("Invalid port token '{}' in port spec '{}'", token, spec));
+                }
+                arr.push_back(port);
             }
         }
-        if (!token.empty()) arr.push_back(std::stoi(token));
         return {{"set", arr}};
     }
-    auto dash = spec.find('-');
-    if (dash != std::string::npos) {
-        int lo = std::stoi(spec.substr(0, dash));
-        int hi = std::stoi(spec.substr(dash + 1));
+
+    if (kind == PortSpecKind::Range) {
+        int lo = 0;
+        int hi = 0;
+        if (!parse_port_range(spec, lo, hi)) {
+            throw std::invalid_argument(keen_pbr3::format("Invalid port range '{}'", spec));
+        }
         return {{"range", nlohmann::json::array({lo, hi})}};
     }
-    return std::stoi(spec);
+
+    int port = 0;
+    if (!parse_port_value(spec, port)) {
+        throw std::invalid_argument(keen_pbr3::format("Invalid port '{}'", spec));
+    }
+    return port;
 }
 
 // --- Private static helpers ---

--- a/src/firewall/port_spec_util.cpp
+++ b/src/firewall/port_spec_util.cpp
@@ -1,0 +1,110 @@
+#include "port_spec_util.hpp"
+#include "../util/format_compat.hpp"
+
+#include <cctype>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace keen_pbr3 {
+
+bool parse_port_value(const std::string& token, int& out) {
+    if (token.empty()) {
+        return false;
+    }
+
+    long long value = 0;
+    for (char c : token) {
+        if (!std::isdigit(static_cast<unsigned char>(c))) {
+            return false;
+        }
+
+        value = value * 10 + (c - '0');
+        if (value > std::numeric_limits<int>::max()) {
+            return false;
+        }
+    }
+
+    if (value < 1 || value > 65535) {
+        return false;
+    }
+
+    out = static_cast<int>(value);
+    return true;
+}
+
+bool parse_port_range(const std::string& token, int& lo, int& hi) {
+    const auto dash = token.find('-');
+    if (dash == std::string::npos) {
+        if (!parse_port_value(token, lo)) {
+            return false;
+        }
+        hi = lo;
+        return true;
+    }
+
+    if (token.find('-', dash + 1) != std::string::npos) {
+        return false;
+    }
+
+    if (!parse_port_value(token.substr(0, dash), lo) ||
+        !parse_port_value(token.substr(dash + 1), hi)) {
+        return false;
+    }
+
+    return lo <= hi;
+}
+
+PortSpecKind classify_port_spec(const std::string& spec) {
+    if (spec.find(',') != std::string::npos) {
+        return PortSpecKind::List;
+    }
+    if (spec.find('-') != std::string::npos) {
+        return PortSpecKind::Range;
+    }
+    return PortSpecKind::Single;
+}
+
+std::vector<std::string> split_port_spec_tokens(const std::string& spec) {
+    std::vector<std::string> tokens;
+    std::string token;
+    for (char c : spec) {
+        if (c == ',') {
+            if (token.empty()) {
+                throw std::invalid_argument(keen_pbr3::format("Invalid empty token in port spec '{}'", spec));
+            }
+            tokens.push_back(token);
+            token.clear();
+        } else {
+            token += c;
+        }
+    }
+    if (token.empty()) {
+        throw std::invalid_argument(keen_pbr3::format("Invalid empty token in port spec '{}'", spec));
+    }
+    tokens.push_back(token);
+    return tokens;
+}
+
+std::string normalize_port_spec_for_iptables(const std::string& spec) {
+    std::vector<std::string> tokens = split_port_spec_tokens(spec);
+    std::string normalized;
+    for (size_t i = 0; i < tokens.size(); ++i) {
+        int lo = 0;
+        int hi = 0;
+        if (!parse_port_range(tokens[i], lo, hi)) {
+            throw std::invalid_argument(keen_pbr3::format("Invalid port token '{}' in port spec '{}'", tokens[i], spec));
+        }
+
+        if (i != 0) {
+            normalized += ",";
+        }
+        normalized += (lo == hi)
+            ? std::to_string(lo)
+            : keen_pbr3::format("{}:{}", lo, hi);
+    }
+
+    return normalized;
+}
+
+} // namespace keen_pbr3

--- a/src/firewall/port_spec_util.hpp
+++ b/src/firewall/port_spec_util.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace keen_pbr3 {
+
+enum class PortSpecKind {
+    Single,
+    Range,
+    List
+};
+
+bool parse_port_value(const std::string& token, int& out);
+bool parse_port_range(const std::string& token, int& lo, int& hi);
+PortSpecKind classify_port_spec(const std::string& spec);
+std::vector<std::string> split_port_spec_tokens(const std::string& spec);
+std::string normalize_port_spec_for_iptables(const std::string& spec);
+
+} // namespace keen_pbr3

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,11 +14,13 @@ add_executable(keen-pbr-tests
   test_config_validation.cpp
   test_routing_state.cpp
   test_system_resolver_hook.cpp
+  test_port_spec_util.cpp
   ../src/config/config.cpp
   ../src/config/routing_state.cpp
   ../src/firewall/iptables_verifier.cpp
   ../src/firewall/nftables_verifier.cpp
   ../src/firewall/firewall_verifier.cpp
+  ../src/firewall/port_spec_util.cpp
   ../src/firewall/nftables.cpp
   ../src/firewall/nft_batch_pipe.cpp
   ../src/firewall/iptables.cpp

--- a/tests/test_iptables_builder.cpp
+++ b/tests/test_iptables_builder.cpp
@@ -230,7 +230,7 @@ TEST_CASE("build_proto_port_fragment: tcp + port list → multiport") {
 
 TEST_CASE("build_proto_port_fragment: src_port + dest_port → multiport") {
   auto frag = T::build_proto_port_fragment("tcp", "1024-65535", "80");
-  CHECK(frag == " -p tcp -m multiport --sports 1024-65535 --dports 80");
+  CHECK(frag == " -p tcp -m multiport --sports 1024:65535 --dports 80");
 }
 
 TEST_CASE("build_proto_port_fragment: proto only, no ports") {
@@ -368,7 +368,7 @@ TEST_CASE(
     "build_proto_port_fragment: both ports negated → single multiport clause") {
   auto frag =
       T::build_proto_port_fragment("tcp", "1024-65535", "80", true, true);
-  CHECK(frag == " -p tcp -m multiport ! --sports 1024-65535 ! --dports 80");
+  CHECK(frag == " -p tcp -m multiport ! --sports 1024:65535 ! --dports 80");
 }
 
 TEST_CASE(

--- a/tests/test_port_spec_util.cpp
+++ b/tests/test_port_spec_util.cpp
@@ -1,0 +1,69 @@
+#include <doctest/doctest.h>
+
+#include "../src/firewall/port_spec_util.hpp"
+
+#include <stdexcept>
+#include <string>
+
+using namespace keen_pbr3;
+
+TEST_CASE("parse_port_value validates bounds and digits") {
+    int value = 0;
+    CHECK(parse_port_value("1", value));
+    CHECK(value == 1);
+    CHECK(parse_port_value("65535", value));
+    CHECK(value == 65535);
+
+    CHECK_FALSE(parse_port_value("", value));
+    CHECK_FALSE(parse_port_value("0", value));
+    CHECK_FALSE(parse_port_value("65536", value));
+    CHECK_FALSE(parse_port_value("12x", value));
+}
+
+TEST_CASE("parse_port_range parses single and range tokens") {
+    int lo = 0;
+    int hi = 0;
+
+    CHECK(parse_port_range("443", lo, hi));
+    CHECK(lo == 443);
+    CHECK(hi == 443);
+
+    CHECK(parse_port_range("8000-9000", lo, hi));
+    CHECK(lo == 8000);
+    CHECK(hi == 9000);
+
+    CHECK_FALSE(parse_port_range("9000-8000", lo, hi));
+    CHECK_FALSE(parse_port_range("80-90-100", lo, hi));
+    CHECK_FALSE(parse_port_range("-80", lo, hi));
+    CHECK_FALSE(parse_port_range("80-", lo, hi));
+}
+
+TEST_CASE("classify_port_spec detects single, range and list") {
+    CHECK(classify_port_spec("443") == PortSpecKind::Single);
+    CHECK(classify_port_spec("8000-9000") == PortSpecKind::Range);
+    CHECK(classify_port_spec("80,443") == PortSpecKind::List);
+    CHECK(classify_port_spec("80,8000-9000") == PortSpecKind::List);
+}
+
+TEST_CASE("split_port_spec_tokens validates list token boundaries") {
+    auto tokens = split_port_spec_tokens("80,443,8080-8090");
+    REQUIRE(tokens.size() == 3);
+    CHECK(tokens[0] == "80");
+    CHECK(tokens[1] == "443");
+    CHECK(tokens[2] == "8080-8090");
+
+    CHECK_THROWS_AS(split_port_spec_tokens(",80"), std::invalid_argument);
+    CHECK_THROWS_AS(split_port_spec_tokens("80,"), std::invalid_argument);
+    CHECK_THROWS_AS(split_port_spec_tokens("80,,443"), std::invalid_argument);
+}
+
+TEST_CASE("normalize_port_spec_for_iptables converts range syntax and validates") {
+    CHECK(normalize_port_spec_for_iptables("443") == "443");
+    CHECK(normalize_port_spec_for_iptables("8000-9000") == "8000:9000");
+    CHECK(normalize_port_spec_for_iptables("80,443,1000-2000") == "80,443,1000:2000");
+
+    CHECK_THROWS_AS(normalize_port_spec_for_iptables("0"), std::invalid_argument);
+    CHECK_THROWS_AS(normalize_port_spec_for_iptables("65536"), std::invalid_argument);
+    CHECK_THROWS_AS(normalize_port_spec_for_iptables("abc"), std::invalid_argument);
+    CHECK_THROWS_AS(normalize_port_spec_for_iptables("9000-1000"), std::invalid_argument);
+}


### PR DESCRIPTION
### Motivation

- Centralize parsing, validation and normalization of port specifications to avoid duplicated logic across nftables and iptables builders.
- Support lists, ranges and single ports with explicit validation and normalized output for different backends.

### Description

- Introduce `src/firewall/port_spec_util.hpp` and `src/firewall/port_spec_util.cpp` providing `PortSpecKind`, `classify_port_spec`, `parse_port_value`, `parse_port_range`, `split_port_spec_tokens`, and `normalize_port_spec_for_iptables` utilities.
- Update `src/firewall/iptables.cpp` to use `classify_port_spec` and `normalize_port_spec_for_iptables` when building iptables port match fragments and remove previous ad-hoc parsing logic.
- Update `src/firewall/nftables.cpp` to use `classify_port_spec`, `split_port_spec_tokens`, `parse_port_range`, and `parse_port_value` to build proper nftables JSON RHS values for single, range and list specs with validation.
- Add the new source to `CMakeLists.txt` and `tests/CMakeLists.txt` and include `test_port_spec_util.cpp` and `../src/firewall/port_spec_util.cpp` in the unit test target.

### Testing

- Ran the unit test executable `keen-pbr-tests`, which includes `test_port_spec_util.cpp`, `test_iptables_builder.cpp` and `test_nftables_builder.cpp` among others, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7df147278832ab634ed4562337454)