### PR TITLE
Serialize URL test-triggered routing/firewall updates

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -290,12 +290,12 @@ void Daemon::handle_signal() {
 }
 
 void Daemon::handle_sigusr1() {
-    std::unique_lock<std::shared_mutex> lock(state_mutex_);
     auto& log = Logger::instance();
     log.info("SIGUSR1: verifying routing tables and triggering URL tests...");
 
     // Re-add static routing tables/ip rules in case they were lost
     try {
+        std::unique_lock<std::shared_mutex> lock(state_mutex_);
         route_table_.clear();
         policy_rules_.clear();
         setup_static_routing();
@@ -734,18 +734,21 @@ void Daemon::register_urltest_outbounds() {
     urltest_manager_ = std::make_unique<UrltestManager>(
         url_tester_, outbound_marks_, *scheduler_,
         [this](const std::string& urltest_tag, const std::string& new_child_tag) {
-            auto& log = Logger::instance();
-            log.info("Urltest '{}' selected outbound: '{}'", urltest_tag, new_child_tag);
-            firewall_state_.set_urltest_selection(urltest_tag, new_child_tag);
-            try {
-                route_table_.clear();
-                policy_rules_.clear();
-                setup_static_routing();
-                apply_firewall();
-                log.info("Routing and firewall rebuilt after urltest change.");
-            } catch (const std::exception& e) {
-                log.error("Error rebuilding routing/firewall after urltest change: {}", e.what());
-            }
+            enqueue_control_task([this, urltest_tag, new_child_tag]() {
+                auto& log = Logger::instance();
+                std::unique_lock<std::shared_mutex> lock(state_mutex_);
+                log.info("Urltest '{}' selected outbound: '{}'", urltest_tag, new_child_tag);
+                firewall_state_.set_urltest_selection(urltest_tag, new_child_tag);
+                try {
+                    route_table_.clear();
+                    policy_rules_.clear();
+                    setup_static_routing();
+                    apply_firewall();
+                    log.info("Routing and firewall rebuilt after urltest change.");
+                } catch (const std::exception& e) {
+                    log.error("Error rebuilding routing/firewall after urltest change: {}", e.what());
+                }
+            });
         });
 
     for (const auto& ob : config_.outbounds.value_or(std::vector<Outbound>{})) {


### PR DESCRIPTION
### Motivation
- Prevent concurrent mutations of routing/firewall state that could occur when a URL test selection callback calls `apply_firewall()` while `handle_sigusr1()` also manipulates the same shared state, which could lead to partial/corrupted firewall state.

### Description
- Update the URL test change callback in `register_urltest_outbounds()` to enqueue the rebuild work via `enqueue_control_task(...)` so it runs on the daemon control thread and serializes state changes.
- Acquire `state_mutex_` inside the enqueued task before updating `firewall_state_`, clearing `route_table_`/`policy_rules_`, and calling `setup_static_routing()` and `apply_firewall()` to ensure consistent synchronization with other state-mutating paths.
- Narrow the lock scope in `handle_sigusr1()` so the routing verification runs under `state_mutex_` but the immediate URL test triggers (`trigger_immediate_test`) occur after releasing the lock, avoiding lock re-entry/deadlock when callbacks run on the control thread.

### Testing
- Ran `make` from the repository root as required by `AGENTS.md`; CMake configuration failed in this environment because the `libnl-3.0` pkg-config dependency is missing, so a full build could not be completed.
- No automated unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ea7c96b0832ab32e8f343af2c7e6)