### PR TITLE
Use hex string fwmark start/mask across API, config, and docs

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -121,8 +121,8 @@
   },
 
   "fwmark": {
-    "start": 65536,
-    "mask": 16711680
+    "start": "0x00010000",
+    "mask": "0x00FF0000"
   },
 
   "iproute": {

--- a/docs/content/docs/configuration/_index.md
+++ b/docs/content/docs/configuration/_index.md
@@ -110,8 +110,8 @@ The following is the full annotated example configuration:
   },
 
   "fwmark": {
-    "start": 65536,
-    "mask": 16711680
+    "start": "0x00010000",
+    "mask": "0x00FF0000"
   },
 
   "iproute": {

--- a/docs/content/docs/configuration/advanced.md
+++ b/docs/content/docs/configuration/advanced.md
@@ -51,14 +51,14 @@ Controls the firewall mark range used to tag packets for policy routing.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `start` | integer | `65536` | First fwmark value to assign to outbounds (`0x00010000`) |
-| `mask` | integer | `16711680` | Fwmark bitmask (`0x00FF0000`) |
+| `start` | string | `"0x00010000"` | First fwmark value to assign to outbounds |
+| `mask` | string | `"0x00FF0000"` | Fwmark bitmask |
 
 ```json
 {
   "fwmark": {
-    "start": 65536,
-    "mask": 16711680
+    "start": "0x00010000",
+    "mask": "0x00FF0000"
   }
 }
 ```

--- a/docs/content/docs/troubleshooting/troubleshooting.md
+++ b/docs/content/docs/troubleshooting/troubleshooting.md
@@ -83,10 +83,10 @@ Adjust to a non-conflicting range:
 ```json
 {
   "fwmark": {
-    "start": 131072,
-    "mask": 16711680
+    "start": "0x00020000",
+    "mask": "0x00FF0000"
   }
 }
 ```
 
-The `mask` must be exactly two adjacent hex nibbles. `16711680` = `0x00FF0000`, `131072` = `0x00020000`.
+The `mask` must be exactly two adjacent hex nibbles. Use hex strings such as `"0x00FF0000"` and `"0x00020000"`.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -583,16 +583,16 @@ components:
       type: object
       properties:
         start:
-          type: integer
-          description: First fwmark value to assign to outbounds.
-          default: 65536
-          example: 65536
+          type: string
+          description: First fwmark value to assign to outbounds as hex string.
+          default: "0x00010000"
+          example: "0x00010000"
         mask:
-          type: integer
+          type: string
           description: >
-            Fwmark bitmask. Must be exactly two adjacent hex nibbles (e.g. 0x00FF0000).
-          default: 16711680
-          example: 16711680
+            Fwmark bitmask as hex string. Must be exactly two adjacent hex nibbles (e.g. 0x00FF0000).
+          default: "0x00FF0000"
+          example: "0x00FF0000"
 
     IprouteConfig:
       type: object
@@ -714,8 +714,8 @@ components:
               server: "vpn-dns"
           fallback: "google-dns"
         fwmark:
-          start: 65536
-          mask: 16711680
+          start: "0x00010000"
+          mask: "0x00FF0000"
         iproute:
           table_start: 150
         lists_autoupdate:

--- a/frontend/src/api/generated/model/fwmarkConfig.ts
+++ b/frontend/src/api/generated/model/fwmarkConfig.ts
@@ -8,8 +8,8 @@
 
 export interface FwmarkConfig {
   /** First fwmark value to assign to outbounds. */
-  start?: number;
+  start?: string;
   /** Fwmark bitmask. Must be exactly two adjacent hex nibbles (e.g. 0x00FF0000).
    */
-  mask?: number;
+  mask?: string;
 }

--- a/frontend/src/pages/general-config-page.tsx
+++ b/frontend/src/pages/general-config-page.tsx
@@ -589,8 +589,6 @@ function buildUpdatedConfig(
   config: ConfigObject,
   draft: SettingsDraft
 ): ConfigObject {
-  const fwmarkStart = parseStrictHexToNumber(draft.fwmarkStart)
-  const fwmarkMask = parseStrictHexToNumber(draft.fwmarkMask)
   const tableStart = parseStrictDecimalToNumber(draft.tableStart)
 
   return {
@@ -601,8 +599,8 @@ function buildUpdatedConfig(
     },
     fwmark: {
       ...config.fwmark,
-      start: toBackendIntegerValue(fwmarkStart, draft.fwmarkStart.trim()),
-      mask: toBackendIntegerValue(fwmarkMask, draft.fwmarkMask.trim()),
+      start: draft.fwmarkStart.trim(),
+      mask: draft.fwmarkMask.trim(),
     },
     iproute: {
       ...config.iproute,
@@ -616,12 +614,17 @@ function buildUpdatedConfig(
   }
 }
 
-function toHex32(value: number | undefined, fallback: string) {
-  if (!Number.isInteger(value)) {
+function toHex32(value: string | undefined, fallback: string) {
+  if (!value) {
     return fallback
   }
 
-  const normalized = ((value ?? 0) >>> 0).toString(16)
+  const trimmed = value.trim()
+  if (!/^0x[0-9a-fA-F]+$/.test(trimmed)) {
+    return fallback
+  }
+
+  const normalized = trimmed.slice(2).replace(/^0+/, "") || "0"
   return `0x${normalized.padStart(8, "0")}`
 }
 
@@ -631,15 +634,6 @@ function toStringInt(value: number | undefined, fallback: string) {
   }
 
   return String(value)
-}
-
-function parseStrictHexToNumber(value: string) {
-  const trimmed = value.trim()
-  if (!/^0x[0-9a-fA-F]+$/.test(trimmed)) {
-    return null
-  }
-
-  return Number.parseInt(trimmed.slice(2), 16)
 }
 
 function parseStrictDecimalToNumber(value: string) {

--- a/packages/common/config.full.example.json
+++ b/packages/common/config.full.example.json
@@ -121,8 +121,8 @@
   },
 
   "fwmark": {
-    "start": 65536,
-    "mask": 16711680
+    "start": "0x00010000",
+    "mask": "0x00FF0000"
   },
 
   "iproute": {

--- a/packages/common/config.headless.example.json
+++ b/packages/common/config.headless.example.json
@@ -116,8 +116,8 @@
   },
 
   "fwmark": {
-    "start": 65536,
-    "mask": 16711680
+    "start": "0x00010000",
+    "mask": "0x00FF0000"
   },
 
   "iproute": {

--- a/src/api/generated/api_types.hpp
+++ b/src/api/generated/api_types.hpp
@@ -158,8 +158,8 @@ namespace api {
     };
 
     struct Fwmark {
-        std::optional<int64_t> mask;
-        std::optional<int64_t> start;
+        std::optional<std::string> mask;
+        std::optional<std::string> start;
     };
 
     struct Iproute {
@@ -770,8 +770,8 @@ namespace api {
     }
 
     inline void from_json(const json & j, Fwmark& x) {
-        x.mask = get_stack_optional<int64_t>(j, "mask");
-        x.start = get_stack_optional<int64_t>(j, "start");
+        x.mask = get_stack_optional<std::string>(j, "mask");
+        x.start = get_stack_optional<std::string>(j, "start");
     }
 
     inline void to_json(json & j, const Fwmark & x) {

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -44,11 +44,11 @@ void validate_optional_integer_field(const json& root,
     }
 }
 
-void validate_optional_string_field(const json& root,
-                                    const char* parent_key,
-                                    const char* child_key,
-                                    const std::string& path,
-                                    std::vector<ConfigValidationIssue>& issues) {
+void validate_optional_hex_string_field(const json& root,
+                                        const char* parent_key,
+                                        const char* child_key,
+                                        const std::string& path,
+                                        std::vector<ConfigValidationIssue>& issues) {
     const auto parent_it = root.find(parent_key);
     if (parent_it == root.end() || !parent_it->is_object()) {
         return;
@@ -331,9 +331,9 @@ Config parse_config(const std::string& json_str) {
         });
     }
 
-    validate_optional_string_field(
+    validate_optional_hex_string_field(
         parsed_json, "fwmark", "start", "fwmark.start", issues);
-    validate_optional_string_field(
+    validate_optional_hex_string_field(
         parsed_json, "fwmark", "mask", "fwmark.mask", issues);
     validate_optional_integer_field(
         parsed_json, "iproute", "table_start", "iproute.table_start", issues);

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -44,6 +44,26 @@ void validate_optional_integer_field(const json& root,
     }
 }
 
+void validate_optional_string_field(const json& root,
+                                    const char* parent_key,
+                                    const char* child_key,
+                                    const std::string& path,
+                                    std::vector<ConfigValidationIssue>& issues) {
+    const auto parent_it = root.find(parent_key);
+    if (parent_it == root.end() || !parent_it->is_object()) {
+        return;
+    }
+
+    const auto child_it = parent_it->find(child_key);
+    if (child_it == parent_it->end() || child_it->is_null()) {
+        return;
+    }
+
+    if (!child_it->is_string()) {
+        add_issue(issues, path, path + " must be a string in hex format (e.g. 0x00010000)");
+    }
+}
+
 std::string trim_copy(const std::string& value) {
     const auto begin = value.find_first_not_of(" \t\n\r\f\v");
     if (begin == std::string::npos) {
@@ -254,6 +274,50 @@ static void validate_fwmark_mask(uint32_t mask) {
     }
 }
 
+uint32_t parse_fwmark_hex_or_throw(const std::optional<std::string>& raw,
+                                   uint32_t default_value,
+                                   const std::string& path) {
+    if (!raw.has_value()) {
+        return default_value;
+    }
+
+    const std::string value = trim_copy(*raw);
+    if (value.empty()) {
+        throw ConfigError(path + " must not be empty");
+    }
+
+    if (value.size() < 3 || value[0] != '0' || (value[1] != 'x' && value[1] != 'X')) {
+        throw ConfigError(path + " must be a hexadecimal string with 0x prefix");
+    }
+
+    for (size_t i = 2; i < value.size(); ++i) {
+        if (!std::isxdigit(static_cast<unsigned char>(value[i]))) {
+            throw ConfigError(path + " must contain only hexadecimal digits");
+        }
+    }
+
+    unsigned long parsed = 0;
+    try {
+        parsed = std::stoul(value, nullptr, 16);
+    } catch (const std::exception&) {
+        throw ConfigError(path + " must be a valid 32-bit hexadecimal value");
+    }
+
+    if (parsed > std::numeric_limits<uint32_t>::max()) {
+        throw ConfigError(path + " must fit into 32 bits (max 0xFFFFFFFF)");
+    }
+
+    return static_cast<uint32_t>(parsed);
+}
+
+uint32_t parse_fwmark_start_or_throw(const FwmarkConfig& fwmark_cfg) {
+    return parse_fwmark_hex_or_throw(fwmark_cfg.start, 0x00010000, "fwmark.start");
+}
+
+uint32_t parse_fwmark_mask_or_throw(const FwmarkConfig& fwmark_cfg) {
+    return parse_fwmark_hex_or_throw(fwmark_cfg.mask, 0x00FF0000, "fwmark.mask");
+}
+
 Config parse_config(const std::string& json_str) {
     Config cfg;
     json parsed_json;
@@ -267,9 +331,9 @@ Config parse_config(const std::string& json_str) {
         });
     }
 
-    validate_optional_integer_field(
+    validate_optional_string_field(
         parsed_json, "fwmark", "start", "fwmark.start", issues);
-    validate_optional_integer_field(
+    validate_optional_string_field(
         parsed_json, "fwmark", "mask", "fwmark.mask", issues);
     validate_optional_integer_field(
         parsed_json, "iproute", "table_start", "iproute.table_start", issues);
@@ -430,19 +494,28 @@ void validate_config(const Config& cfg) {
         }
     }
 
-    const uint32_t fwmark_mask = static_cast<uint32_t>(
-        cfg.fwmark.value_or(FwmarkConfig{}).mask.value_or(0x00FF0000));
+    const FwmarkConfig fwmark_cfg = cfg.fwmark.value_or(FwmarkConfig{});
+    bool fwmark_start_valid = true;
+    try {
+        (void)parse_fwmark_start_or_throw(fwmark_cfg);
+    } catch (const ConfigError& e) {
+        fwmark_start_valid = false;
+        add_issue(issues, "fwmark.start", e.what());
+    }
+
+    uint32_t fwmark_mask = 0;
     bool fwmark_mask_valid = true;
     try {
+        fwmark_mask = parse_fwmark_mask_or_throw(fwmark_cfg);
         validate_fwmark_mask(fwmark_mask);
     } catch (const ConfigError& e) {
         fwmark_mask_valid = false;
         add_issue(issues, "fwmark.mask", e.what());
     }
 
-    if (fwmark_mask_valid) {
+    if (fwmark_start_valid && fwmark_mask_valid) {
         try {
-            (void)allocate_outbound_marks(cfg.fwmark.value_or(FwmarkConfig{}), outbounds);
+            (void)allocate_outbound_marks(fwmark_cfg, outbounds);
         } catch (const ConfigError& e) {
             add_issue(issues, "outbounds", e.what());
         }
@@ -579,8 +652,8 @@ Config parse_and_validate_config(const std::string& json_str) {
 
 OutboundMarkMap allocate_outbound_marks(const FwmarkConfig& fwmark_cfg,
                                          const std::vector<Outbound>& outbounds) {
-    uint32_t mask  = static_cast<uint32_t>(fwmark_cfg.mask.value_or(0x00FF0000));
-    uint32_t start = static_cast<uint32_t>(fwmark_cfg.start.value_or(0x00010000));
+    uint32_t mask  = parse_fwmark_mask_or_throw(fwmark_cfg);
+    uint32_t start = parse_fwmark_start_or_throw(fwmark_cfg);
 
     validate_fwmark_mask(mask);
 
@@ -610,6 +683,16 @@ OutboundMarkMap allocate_outbound_marks(const FwmarkConfig& fwmark_cfg,
     }
 
     return mark_map;
+}
+
+uint32_t fwmark_start_value(const FwmarkConfig& fwmark_cfg) {
+    return parse_fwmark_start_or_throw(fwmark_cfg);
+}
+
+uint32_t fwmark_mask_value(const FwmarkConfig& fwmark_cfg) {
+    const uint32_t mask = parse_fwmark_mask_or_throw(fwmark_cfg);
+    validate_fwmark_mask(mask);
+    return mask;
 }
 
 } // namespace keen_pbr3

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -77,4 +77,7 @@ using OutboundMarkMap = std::map<std::string, uint32_t>;
 OutboundMarkMap allocate_outbound_marks(const FwmarkConfig& fwmark_cfg,
                                          const std::vector<Outbound>& outbounds);
 
+uint32_t fwmark_start_value(const FwmarkConfig& fwmark_cfg);
+uint32_t fwmark_mask_value(const FwmarkConfig& fwmark_cfg);
+
 } // namespace keen_pbr3

--- a/src/config/routing_state.cpp
+++ b/src/config/routing_state.cpp
@@ -172,8 +172,7 @@ void populate_routing_state(const Config& cfg,
     const auto& outbounds = cfg.outbounds.value_or(std::vector<Outbound>{});
     const uint32_t table_start = static_cast<uint32_t>(
         cfg.iproute.value_or(IprouteConfig{}).table_start.value_or(100));
-    const uint32_t fwmark_mask = static_cast<uint32_t>(
-        cfg.fwmark.value_or(FwmarkConfig{}).mask.value_or(0x00FF0000));
+    const uint32_t fwmark_mask = fwmark_mask_value(cfg.fwmark.value_or(FwmarkConfig{}));
 
     uint32_t table_offset = 0;
     for (const auto& ob : outbounds) {

--- a/tests/test_config_validation.cpp
+++ b/tests/test_config_validation.cpp
@@ -430,11 +430,16 @@ TEST_CASE("iproute.table_start: non-integer value is rejected") {
 TEST_CASE("fwmark mask: invalid value is rejected during config parsing") {
     const std::string json = R"({
         "fwmark": {
-            "mask": 4294901761
+            "mask": "0xFFFF0001"
         }
     })";
 
     CHECK_THROWS_AS(parse_test_config(json), ConfigValidationError);
+}
+
+TEST_CASE("fwmark start and mask: non-string values are rejected during config parsing") {
+    CHECK_THROWS_AS(parse_test_config(R"({"fwmark":{"start":65536}})"), ConfigValidationError);
+    CHECK_THROWS_AS(parse_test_config(R"({"fwmark":{"mask":16711680}})"), ConfigValidationError);
 }
 
 TEST_CASE("config parsing returns all collected validation errors") {
@@ -443,7 +448,7 @@ TEST_CASE("config parsing returns all collected validation errors") {
             "enabled": true
         },
         "fwmark": {
-            "mask": 4294901761
+            "mask": "0xFFFF0001"
         },
         "lists": {
             "bad-list": {}
@@ -494,4 +499,3 @@ TEST_CASE("daemon.firewall_verify_max_bytes: rejects non-integer value") {
 TEST_CASE("daemon.firewall_verify_max_bytes: rejects negative value") {
     CHECK_THROWS_AS(parse_test_config(R"({"daemon":{"firewall_verify_max_bytes":-1}})"), ConfigError);
 }
-


### PR DESCRIPTION
### Motivation
- Prevent silent integer truncation of `fwmark.start`/`fwmark.mask` (nlohmann::json stores integers as 64-bit) and make fwmark values human-friendly and unambiguous by using hex strings.
- Centralize strict parsing/validation of fwmark values before they are converted to the internal 32-bit marks used for routing and firewall rules.

### Description
- Switched generated API/backend types for `Fwmark` so `start` and `mask` are `string` instead of integer (`src/api/generated/api_types.hpp` and `frontend/src/api/generated/model/fwmarkConfig.ts`).
- Added string-field validation and strict hex parsing helpers: `validate_optional_string_field`, `parse_fwmark_hex_or_throw`, `parse_fwmark_start_or_throw`, and `parse_fwmark_mask_or_throw` in `src/config/config.cpp` and exposed `fwmark_start_value` / `fwmark_mask_value` via `src/config/config.hpp`.
- Replaced previous implicit integer conversions with explicit parsing and validation in parsing/validation paths and in `allocate_outbound_marks` and routing population (`src/config/config.cpp`, `src/config/routing_state.cpp`).
- Updated frontend settings flow to treat fwmark `start`/`mask` as strings and send them unchanged to backend while normalizing display (`frontend/src/pages/general-config-page.tsx`).
- Updated OpenAPI schema/examples, user docs, and shipped config examples/defaults to use hex string fwmark values (`docs/openapi.yaml`, docs content files, `config.example.json`, package example configs).
- Adjusted unit tests to expect string fwmark inputs and added a test asserting numeric fwmark values are rejected at parse-time (`tests/test_config_validation.cpp`).

### Testing
- Updated unit test file `tests/test_config_validation.cpp` to reflect string-based fwmark fields and to add coverage for rejecting numeric `fwmark.start`/`fwmark.mask` inputs (tests modified but not executed here).
- Attempted to build with `make` in this environment; CMake configure failed because `libnl-3.0` was not present, so full build and test execution could not be completed (error: missing `libnl-3.0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7eafc23e8832aaa08a7490725a7b9)