### PR TITLE
Use CLOEXEC pipes in safe_exec helpers

### DIFF
--- a/src/util/safe_exec.hpp
+++ b/src/util/safe_exec.hpp
@@ -60,7 +60,7 @@ inline int safe_exec_pipe_stdin(const std::vector<std::string>& args,
     argv.push_back(nullptr);
 
     int pipefd[2];
-    if (pipe(pipefd) == -1) return -1;
+    if (pipe2(pipefd, O_CLOEXEC) == -1) return -1;
 
     const pid_t pid = fork();
     if (pid == -1) {
@@ -114,7 +114,7 @@ inline std::string safe_exec_capture(const std::vector<std::string>& args,
     argv.push_back(nullptr);
 
     int pipefd[2];
-    if (pipe(pipefd) == -1) return {};
+    if (pipe2(pipefd, O_CLOEXEC) == -1) return {};
 
     const pid_t pid = fork();
     if (pid == -1) {


### PR DESCRIPTION
### Motivation
- Prevent leakage of pipe file descriptors into unrelated child processes by atomically setting close-on-exec on pipes created for helper exec functions.

### Description
- Replaced `pipe()` with `pipe2(..., O_CLOEXEC)` in `safe_exec_pipe_stdin` and `safe_exec_capture` in `src/util/safe_exec.hpp` so pipe FDs are created with `FD_CLOEXEC` atomically.

### Testing
- Ran the project build via `make`, which failed during CMake configure due to a missing system package (`libnl-3.0`), so no successful compile or unit-test run was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ed52a3dc832aa1ae24082f2e3c05)