### PR TITLE
Harden IPv6 validation for DNS and list parsing

### DIFF
--- a/src/config/list_parser.cpp
+++ b/src/config/list_parser.cpp
@@ -1,5 +1,7 @@
 #include "list_parser.hpp"
 
+#include <arpa/inet.h>
+
 #include <algorithm>
 #include <charconv>
 
@@ -35,28 +37,14 @@ bool ListParser::is_ipv4(std::string_view s) {
 
 bool ListParser::is_ipv6(std::string_view s) {
     if (s.empty()) return false;
-    // Basic IPv6 validation: must contain at least one colon and only hex digits, colons, and dots (for mapped v4)
-    if (s.find(':') == std::string_view::npos) return false;
-    // Reject if contains slash (that's CIDR)
+    // Reject CIDR suffixes and scoped zone IDs. This parser classifies plain IPs;
+    // CIDR is handled separately and zone IDs are not supported downstream.
     if (s.find('/') != std::string_view::npos) return false;
+    if (s.find('%') != std::string_view::npos) return false;
 
-    int colons = 0;
-    bool has_double_colon = false;
-    for (size_t i = 0; i < s.size(); ++i) {
-        char c = s[i];
-        if (c == ':') {
-            ++colons;
-            if (i + 1 < s.size() && s[i + 1] == ':') {
-                if (has_double_colon) return false; // only one :: allowed
-                has_double_colon = true;
-            }
-        } else if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
-                     (c >= 'A' && c <= 'F') || c == '.')) {
-            return false;
-        }
-    }
-    // Must have at least 1 colon, max 7 (or fewer with ::)
-    return colons >= 1 && colons <= 7;
+    std::string ip(s);
+    in6_addr parsed{};
+    return inet_pton(AF_INET6, ip.c_str(), &parsed) == 1;
 }
 
 bool ListParser::is_cidr_v4(std::string_view s) {

--- a/src/dns/dns_server.cpp
+++ b/src/dns/dns_server.cpp
@@ -1,5 +1,7 @@
 #include "dns_server.hpp"
 
+#include <arpa/inet.h>
+
 #include <charconv>
 #include <cstdint>
 
@@ -29,27 +31,12 @@ bool is_valid_ipv4(const std::string& addr) {
 bool is_valid_ipv6(const std::string& addr) {
     if (addr.empty()) return false;
 
-    // Must contain at least one colon
-    if (addr.find(':') == std::string::npos) return false;
+    // Scoped IPv6 zone IDs ("%eth0", "%1") are intentionally rejected here.
+    // The rest of the codebase treats addresses as plain numeric literals.
+    if (addr.find('%') != std::string::npos) return false;
 
-    // Check for valid characters
-    for (char c : addr) {
-        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
-              (c >= 'A' && c <= 'F') || c == ':' || c == '.')) {
-            return false;
-        }
-    }
-
-    // Basic structure: groups separated by colons, :: allowed once
-    int double_colon_count = 0;
-    size_t pos = 0;
-    while ((pos = addr.find("::", pos)) != std::string::npos) {
-        ++double_colon_count;
-        pos += 2;
-    }
-    if (double_colon_count > 1) return false;
-
-    return true;
+    in6_addr parsed{};
+    return inet_pton(AF_INET6, addr.c_str(), &parsed) == 1;
 }
 
 bool is_valid_ip(const std::string& addr) {


### PR DESCRIPTION
### Motivation
- Existing IPv6 validators performed only shallow checks (allowed any hex/colon/dot characters and at most one `::`) and did not enforce group counts, group lengths, or reject zone IDs, which can lead to downstream `inet_pton` or netlink parsing errors or unexpected routing behavior. 
- The goal is to ensure callers only accept canonical, parseable IPv6 literals and to block unsupported scoped zone IDs before they reach routing/resolution code. 

### Description
- Replace ad-hoc IPv6 validation logic with a canonical parse using `inet_pton(AF_INET6, ...)` in `src/dns/dns_server.cpp` and `src/config/list_parser.cpp` to enforce correct IPv6 structure. 
- Explicitly reject scoped zone IDs (`%...`) in both validators so scoped literals are not forwarded to downstream components. 
- Add `#include <arpa/inet.h>` in the modified files and preserve the existing CIDR-vs-IP classification by continuing to reject `/` in `ListParser::is_ipv6` so CIDR parsing remains the separate code path. 

### Testing
- Ran the project build with `make` from the repository root per project instructions. 
- Build did not complete in this environment because required dependency `libnl-3.0` was not found by `pkg-config`, so no full compile/test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ee7047e0832ab113d69baa429825)