### PR TITLE
Fix non-blocking DNS probe TCP write handling

### DIFF
--- a/src/dns/dns_probe_server.cpp
+++ b/src/dns/dns_probe_server.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <fcntl.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/timerfd.h>
 #include <unistd.h>
@@ -29,6 +30,7 @@ constexpr size_t kMaxTcpClients = 16;
 constexpr size_t kMaxTcpBufferSize = 16384;
 constexpr std::chrono::seconds kTcpClientIdleTimeout{15};
 constexpr std::chrono::seconds kTcpIdleSweepInterval{1};
+constexpr int kTcpWriteWaitTimeoutMs = 1000;
 
 bool is_valid_ipv4(const std::string& ip) {
     struct in_addr addr {};
@@ -128,6 +130,26 @@ bool write_all(int fd, const uint8_t* data, size_t len) {
         ssize_t written = send(fd, data + offset, len - offset, MSG_NOSIGNAL);
         if (written > 0) {
             offset += static_cast<size_t>(written);
+            continue;
+        }
+        if (written < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            pollfd pfd {};
+            pfd.fd = fd;
+            pfd.events = POLLOUT;
+            while (true) {
+                int ready = poll(&pfd, 1, kTcpWriteWaitTimeoutMs);
+                if (ready > 0) {
+                    break;
+                }
+                if (ready == 0) {
+                    errno = EAGAIN;
+                    return false;
+                }
+                if (errno == EINTR) {
+                    continue;
+                }
+                return false;
+            }
             continue;
         }
         if (written < 0 && errno == EINTR) {


### PR DESCRIPTION
### Motivation
- Prevent the TCP send path from spin-looping at 100% CPU when the socket is non-blocking and the peer's receive window is full by properly handling `EAGAIN`/`EWOULDBLOCK`.
- Provide a bounded wait for socket writability to avoid unbounded busy-waiting while preserving existing interrupt handling.

### Description
- Add `#include <poll.h>` and a timeout constant `kTcpWriteWaitTimeoutMs` to `src/dns/dns_probe_server.cpp` for write-wait handling.
- Update `write_all(int, const uint8_t*, size_t)` to detect `EAGAIN`/`EWOULDBLOCK` and wait for `POLLOUT` with `poll()` before retrying `send()`.
- On `poll()` timeout the function sets `errno = EAGAIN` and returns `false`, and existing `EINTR` handling is preserved.

### Testing
- Ran `make` in the repository root which attempted to configure and build the project but failed during CMake configure due to a missing system package (`libnl-3.0`), so a full build/test could not be completed in this environment.
- No additional automated unit tests were run because the configure/build step did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ee965684832abc436cb8a996b3f2)