### PR TITLE
Refactor API endpoints and config management workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Written in C++17, designed for embedded targets (MIPS, ARM, AArch64, x86_64) wit
 ## Features
 
 - **Selective routing** — route traffic through specific interfaces based on IP/CIDR/domain lists
-- **Multiple outbound types** — interface (with optional gateway), routing table, blackhole
+- **Multiple outbound types** — interface (with optional gateway), routing table, blackhole, ignore, urltest (auto-select by latency)
 - **Failover chains** — ordered list of outbounds; first healthy one wins
 - **Health monitoring** — ICMP ping-based checks with circuit breaker to prevent oscillation
 - **Dual firewall backend** — auto-detects iptables/ipset or nftables
 - **DNS integration** — generates dnsmasq config for domain-based routing via ipsets
 - **Remote lists** — download IP/domain lists from URLs with disk caching for offline startup
-- **REST API** (optional, compile-time) — status, health, and reload endpoints
-- **Signal handling** — `SIGUSR1` triggers immediate list reload; `SIGTERM`/`SIGINT` for graceful shutdown
+- **REST API** (optional, compile-time) — service health, routing verification, config management, routing test, DNS test, and reload endpoints
+- **Signal handling** — `SIGHUP` triggers full reload (re-download lists, re-apply rules); `SIGUSR1` re-verifies routing tables and triggers URL tests; `SIGTERM`/`SIGINT` for graceful shutdown
 
 ## Prerequisites
 
@@ -216,15 +216,10 @@ keen-pbr reads a JSON config file whose default path is set at build time (`/etc
         "outbound": "vpn"
       },
       {
-        "list": ["blocked-sites"],
-        "outbounds": ["vpn", "wan"]
-      },
-      {
         "list": ["local-list"],
-        "action": "skip"
+        "outbound": "direct"
       }
-    ],
-    "fallback": "wan"
+    ]
   },
   "dns": {
     "servers": [
@@ -275,13 +270,11 @@ List files (remote or local) contain one entry per line. Supported entry types:
 
 ### Route rules
 
-Each route rule matches traffic against one or more lists and takes an action:
+Each route rule matches traffic against one or more lists and routes it through the specified outbound:
 
-- **Single outbound** (`"outbound": "tag"`) — route to the specified outbound
-- **Failover chain** (`"outbounds": ["tag1", "tag2"]`) — try outbounds in order, use first healthy one
-- **Skip** (`"action": "skip"`) — skip this rule, continue to next
+- `"outbound": "tag"` — route matched traffic to the named outbound
 
-Rules are evaluated in order; first match wins. Unmatched traffic uses the `fallback` outbound.
+Rules are evaluated in order; first match wins.
 
 ## Usage
 
@@ -303,7 +296,8 @@ keen-pbr [options]
 
 | Signal | Effect |
 |---|---|
-| `SIGUSR1` | Trigger immediate list reload |
+| `SIGHUP` | Full reload: re-download lists, re-apply firewall and routing rules |
+| `SIGUSR1` | Re-verify routing tables and trigger immediate URL tests |
 | `SIGTERM` / `SIGINT` | Graceful shutdown (cleanup routes, firewall, PID file) |
 
 ### REST API endpoints
@@ -312,9 +306,15 @@ Available when built with `WITH_API=ON` and not disabled with `--no-api`:
 
 | Method | Endpoint | Description |
 |---|---|---|
-| `GET` | `/api/status` | Daemon status, loaded lists, active outbounds |
-| `GET` | `/api/health` | Health check results for all outbounds |
-| `POST` | `/api/reload` | Trigger list re-download and re-apply |
+| `GET` | `/api/health/service` | Daemon version, status, and resolver config summary |
+| `GET` | `/api/health/routing` | Verify live kernel routing and firewall state |
+| `GET` | `/api/runtime/outbounds` | Live outbound and interface runtime state |
+| `POST` | `/api/reload` | Trigger async full reload (re-download lists, re-apply rules) |
+| `GET` | `/api/config` | Get current config (with draft indicator) |
+| `POST` | `/api/config` | Validate and stage config in memory (no write, no reload) |
+| `POST` | `/api/config/save` | Persist staged config to disk and apply it |
+| `POST` | `/api/routing/test` | Test routing for an IP address or domain name |
+| `GET` | `/api/dns/test` | Stream live DNS test queries as Server-Sent Events |
 
 ### Running on the router
 

--- a/config.example.json
+++ b/config.example.json
@@ -190,7 +190,6 @@
         "dest_addr": "!10.0.0.0/8,172.16.0.0/12",
         "outbound": "block"
       }
-    ],
-    "fallback": "wan"
+    ]
   }
 }

--- a/docs/content/docs/api/endpoints.md
+++ b/docs/content/docs/api/endpoints.md
@@ -9,7 +9,7 @@ All endpoints are served at the configured `api.listen` address (default `127.0.
 
 ## GET /api/health/service
 
-Returns the running daemon version, overall status, and health information for every configured outbound. For `urltest` outbounds, includes per-child probe results, latencies, circuit breaker states, and the currently selected outbound.
+Returns the running daemon version, service status, and resolver configuration summary.
 
 ```bash
 curl http://127.0.0.1:8080/api/health/service
@@ -22,47 +22,14 @@ curl http://127.0.0.1:8080/api/health/service
   "version": "3.0.0",
   "status": "running",
   "resolver_config_hash": "a3f7c1d9e2b84560abcdef1234567890",
-  "outbounds": [
-    {
-      "tag": "vpn",
-      "type": "interface",
-      "status": "healthy"
-    },
-    {
-      "tag": "auto-select",
-      "type": "urltest",
-      "status": "healthy",
-      "selected_outbound": "vpn",
-      "children": [
-        {
-          "tag": "vpn",
-          "success": true,
-          "latency_ms": 42,
-          "circuit_breaker": "closed"
-        },
-        {
-          "tag": "wan",
-          "success": true,
-          "latency_ms": 5,
-          "circuit_breaker": "closed"
-        }
-      ]
-    }
-  ]
+  "resolver_config_hash_actual": "a3f7c1d9e2b84560abcdef1234567890",
+  "config_is_draft": false
 }
 ```
 
-**Outbound status values:**
-- `healthy` — outbound is functioning (for urltest: a child is selected)
-- `degraded` — urltest has no selected outbound
-- `unknown` — urltest state not yet initialized
+`resolver_config_hash` is an MD5 hex digest of the expected domain-to-ipset mapping derived from the current config. `resolver_config_hash_actual` reflects the hash of the config that was last applied to the running system resolver. When these two values differ, the dnsmasq config may be out of date.
 
-**Circuit breaker states:**
-- `closed` — healthy, traffic passes through
-- `open` — failed, blocked during cooldown
-- `half_open` — testing recovery with limited probes
-
-`resolver_config_hash` is an MD5 hex digest of the current domain-to-ipset mapping. Use it to verify the dnsmasq config is up to date.
+For live outbound runtime state (health, latency, circuit breaker) use `GET /api/runtime/outbounds`.
 
 ---
 
@@ -87,7 +54,7 @@ curl -X POST http://127.0.0.1:8080/api/reload
 
 ## GET /api/config
 
-Returns the raw contents of the current configuration file as JSON.
+Returns the current configuration together with a flag indicating whether it is a staged in-memory draft.
 
 ```bash
 curl http://127.0.0.1:8080/api/config
@@ -97,13 +64,18 @@ curl http://127.0.0.1:8080/api/config
 
 ```json
 {
-  "daemon": { "pid_file": "/var/run/keen-pbr.pid", "cache_dir": "/var/cache/keen-pbr" },
-  "api": { "enabled": true, "listen": "127.0.0.1:8080" },
-  "outbounds": [...],
-  "lists": {...},
-  "route": {...}
+  "config": {
+    "daemon": { "pid_file": "/var/run/keen-pbr.pid", "cache_dir": "/var/cache/keen-pbr" },
+    "api": { "enabled": true, "listen": "127.0.0.1:8080" },
+    "outbounds": [],
+    "lists": {},
+    "route": {}
+  },
+  "is_draft": false
 }
 ```
+
+`is_draft` is `true` when a config has been staged via `POST /api/config` but not yet saved to disk.
 
 ### Error Response (500)
 
@@ -117,7 +89,7 @@ curl http://127.0.0.1:8080/api/config
 
 ## POST /api/config
 
-Validates the provided JSON body as a config file, writes it atomically, then triggers a full reload.
+Validates the provided JSON body as a config file and stages it in daemon memory. The config is **not** written to disk and the service is **not** reloaded. Use `POST /api/config/save` to persist and apply.
 
 ```bash
 curl -X POST http://127.0.0.1:8080/api/config \
@@ -130,15 +102,115 @@ curl -X POST http://127.0.0.1:8080/api/config \
 ```json
 {
   "status": "ok",
-  "message": "Config updated and reload triggered"
+  "message": "Config staged in memory"
 }
 ```
 
-### Error Response (500)
+### Error Response (400 — validation error)
 
 ```json
 {
-  "error": "Validation or write error message"
+  "error": "Validation failed",
+  "validation_errors": [
+    { "path": "outbounds.vpn.interface", "message": "interface is required" }
+  ]
+}
+```
+
+---
+
+## POST /api/config/save
+
+Persists the currently staged in-memory config to disk, then applies it with a full service reload.
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/config/save
+```
+
+### Response
+
+```json
+{
+  "status": "ok",
+  "message": "Config saved and applied",
+  "saved": true,
+  "applied": true,
+  "rolled_back": false
+}
+```
+
+### Error Response (400 — no staged config)
+
+```json
+{
+  "error": "No staged config to save",
+  "saved": false,
+  "applied": false,
+  "rolled_back": false
+}
+```
+
+---
+
+## GET /api/runtime/outbounds
+
+Returns the daemon's current outbound runtime state: live urltest selection, interface reachability, and circuit breaker status.
+
+```bash
+curl http://127.0.0.1:8080/api/runtime/outbounds
+```
+
+### Response
+
+```json
+{
+  "outbounds": [
+    {
+      "tag": "vpn",
+      "type": "interface",
+      "status": "healthy",
+      "interfaces": [
+        { "name": "tun0", "status": "up" }
+      ]
+    },
+    {
+      "tag": "auto-select",
+      "type": "urltest",
+      "status": "healthy",
+      "selected_outbound": "vpn"
+    }
+  ]
+}
+```
+
+---
+
+## POST /api/routing/test
+
+Resolves the target (if a domain), scans configured route rules against cached list data to determine the expected outbound, and queries the live kernel firewall sets to determine the actual outbound. Useful for diagnosing routing mismatches without restarting the daemon.
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/routing/test \
+  -H "Content-Type: application/json" \
+  -d '{"target": "example.com"}'
+```
+
+### Response
+
+```json
+{
+  "target": "example.com",
+  "is_domain": true,
+  "resolved_ips": ["93.184.216.34"],
+  "results": [
+    {
+      "ip": "93.184.216.34",
+      "expected_outbound": "vpn",
+      "actual_outbound": "vpn",
+      "ok": true,
+      "list_match": { "list": "my-domains", "via": "domain" }
+    }
+  ]
 }
 ```
 
@@ -222,9 +294,7 @@ curl http://127.0.0.1:8080/api/health/routing
 
 ## GET /api/dns/test
 
-Streams DNS probe query names as Server-Sent Events. The connection receives
-`HELLO` immediately, then one event for each DNS name queried against
-`dns.test_server` while the SSE connection is open.
+Streams DNS queries observed by the built-in `dns.test_server` listener as Server-Sent Events. Each event payload is a JSON object. The connection receives a `HELLO` event immediately, then one `DNS` event per queried name while the connection is open.
 
 ```bash
 curl -N http://127.0.0.1:8080/api/dns/test
@@ -233,10 +303,10 @@ curl -N http://127.0.0.1:8080/api/dns/test
 ### Stream Example
 
 ```text
-data: HELLO
+data: {"type":"HELLO"}
 
-data: example.com
+data: {"type":"DNS","domain":"example.com","source_ip":"192.168.1.10","ecs":"203.0.113.0/24"}
 
-data: connectivity-check.local
+data: {"type":"DNS","domain":"connectivity-check.local","source_ip":"192.168.1.11","ecs":null}
 
 ```

--- a/docs/content/docs/configuration/advanced.md
+++ b/docs/content/docs/configuration/advanced.md
@@ -7,18 +7,24 @@ This page covers the remaining top-level configuration keys: `daemon`, `api`, `f
 
 ## daemon
 
-Controls the PID file path and cache directory.
+Controls the PID file path, cache directory, and global routing behaviour.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `pid_file` | string | — | Path to write the PID file |
 | `cache_dir` | string | `/var/cache/keen-pbr` | Directory for cached list data |
+| `strict_enforcement` | boolean | `false` | Default strict routing enforcement for interface outbounds. When enabled, an unreachable default route is installed if the outbound gateway/interface cannot be confirmed reachable. Can be overridden per-outbound. |
+| `max_file_size_bytes` | integer | `8388608` (8 MiB) | Maximum allowed size in bytes for downloaded remote list content |
+| `firewall_verify_max_bytes` | integer | `262144` | Maximum stdout bytes captured per firewall verification command (`0` = unlimited) |
 
 ```json
 {
   "daemon": {
     "pid_file": "/var/run/keen-pbr.pid",
-    "cache_dir": "/var/cache/keen-pbr"
+    "cache_dir": "/var/cache/keen-pbr",
+    "strict_enforcement": false,
+    "max_file_size_bytes": 8388608,
+    "firewall_verify_max_bytes": 262144
   }
 }
 ```


### PR DESCRIPTION
## Summary
This PR significantly refactors the REST API design and configuration management workflow to separate concerns between service health monitoring, runtime state inspection, and configuration staging/persistence.

## Key Changes

**API Endpoint Restructuring:**
- Simplified `GET /api/health/service` to return only daemon version, status, and resolver config hash (removed detailed outbound/urltest data)
- Moved live outbound runtime state to new `GET /api/runtime/outbounds` endpoint
- Added `POST /api/routing/test` endpoint for diagnosing routing mismatches without daemon restart
- Enhanced `GET /api/dns/test` to stream structured JSON events instead of plain text

**Configuration Management Workflow:**
- Changed `POST /api/config` to validate and stage config in memory without writing to disk or reloading
- Added new `POST /api/config/save` endpoint to persist staged config and trigger reload
- Updated `GET /api/config` response to wrap config in an object with `is_draft` flag indicating staged state
- Removed automatic reload behavior from config POST; now requires explicit save step

**Documentation Updates:**
- Updated README to reflect new API endpoints and signal handling (`SIGHUP` for full reload, `SIGUSR1` for routing verification)
- Clarified route rule behavior: removed `fallback` outbound concept and `action: "skip"` in favor of explicit per-rule outbound routing
- Removed `outbounds` array from route rules (no more failover chains via config)
- Added daemon configuration options: `strict_enforcement`, `max_file_size_bytes`, `firewall_verify_max_bytes`
- Updated feature list to include `urltest` outbound type and expanded REST API capabilities

## Notable Implementation Details
- The two-step config workflow (stage → save) allows validation and preview before persistence
- Resolver config hash comparison (`resolver_config_hash` vs `resolver_config_hash_actual`) enables detection of stale dnsmasq configuration
- New routing test endpoint provides diagnostic capability without service disruption
- DNS test streaming now includes source IP and ECS information in structured format

https://claude.ai/code/session_01GFU59DgmaHLizzWbFFKHV9