### PR TITLE
Handle SIGPIPE to prevent crashes on broken pipe writes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -211,6 +211,7 @@ std::string read_file(const std::string& path) {
 } // anonymous namespace
 
 int main(int argc, char* argv[]) {
+    signal(SIGPIPE, SIG_IGN);
     install_crash_handler();
 
     struct CurlGuard {

--- a/src/util/safe_exec.hpp
+++ b/src/util/safe_exec.hpp
@@ -4,6 +4,7 @@
 #include <signal.h>
 #include <fcntl.h>
 #include <string>
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <vector>
@@ -83,7 +84,7 @@ inline int safe_exec_pipe_stdin(const std::vector<std::string>& args,
     const char* data = input.data();
     size_t remaining = input.size();
     while (remaining > 0) {
-        const ssize_t written = write(pipefd[1], data, remaining);
+        const ssize_t written = send(pipefd[1], data, remaining, MSG_NOSIGNAL);
         if (written < 0) {
             if (errno == EINTR) continue;
             break;


### PR DESCRIPTION
## Summary
This PR fixes potential crashes when writing to pipes that have been closed by the receiving process. The changes prevent SIGPIPE signals from terminating the application and use a safer socket API for pipe writes.

## Key Changes
- Added `#include <sys/socket.h>` to support the `send()` function
- Replaced `write()` with `send()` in `safe_exec_pipe_stdin()` to use `MSG_NOSIGNAL` flag, which prevents SIGPIPE from being raised on broken pipe writes
- Added `signal(SIGPIPE, SIG_IGN)` in `main()` to globally ignore SIGPIPE signals as a defensive measure

## Implementation Details
The changes address the issue where writing to a pipe whose read end has been closed would previously cause a SIGPIPE signal to terminate the process. By using `send()` with the `MSG_NOSIGNAL` flag, the write operation will return an error instead of raising a signal. Additionally, the global SIGPIPE handler ensures robustness even if other code paths attempt to write to closed pipes.

https://claude.ai/code/session_01MuBMcDuTMirGjtKWf5ucJS