### PR TITLE
Make event_loop_thread_id_ atomic with proper memory ordering

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -178,12 +178,12 @@ void Daemon::enqueue_control_task(std::function<void()> task,
     }
 
     if (!event_loop_active_.load(std::memory_order_acquire) ||
-        event_loop_thread_id_ == std::thread::id{}) {
+        event_loop_thread_id_.load(std::memory_order_relaxed) == std::thread::id{}) {
         task();
         return;
     }
 
-    if (event_loop_thread_id_ == std::this_thread::get_id()) {
+    if (event_loop_thread_id_.load(std::memory_order_relaxed) == std::this_thread::get_id()) {
         task();
         return;
     }
@@ -411,7 +411,7 @@ void Daemon::run() {
 
     // --- Event loop ---
     running_.store(true, std::memory_order_release);
-    event_loop_thread_id_ = std::this_thread::get_id();
+    event_loop_thread_id_.store(std::this_thread::get_id(), std::memory_order_relaxed);
     event_loop_active_.store(true, std::memory_order_release);
 
     constexpr int MAX_EVENTS = 16;
@@ -456,7 +456,7 @@ void Daemon::run() {
     }
 
     event_loop_active_.store(false, std::memory_order_release);
-    event_loop_thread_id_ = std::thread::id{};
+    event_loop_thread_id_.store(std::thread::id{}, std::memory_order_relaxed);
 
     // --- Shutdown sequence ---
     log.info("Shutting down...");

--- a/src/daemon/daemon.hpp
+++ b/src/daemon/daemon.hpp
@@ -152,7 +152,7 @@ private:
     int epoll_fd_{-1};
     int signal_fd_{-1};
     std::atomic<bool> running_{false};
-    std::thread::id event_loop_thread_id_{};
+    std::atomic<std::thread::id> event_loop_thread_id_{};
     std::atomic<bool> event_loop_active_{false};
 
     struct FdEntry {


### PR DESCRIPTION
## Summary
Convert `event_loop_thread_id_` from a non-atomic member variable to an `std::atomic<std::thread::id>` and add explicit memory ordering semantics to all accesses.

## Key Changes
- Changed `event_loop_thread_id_` declaration from `std::thread::id` to `std::atomic<std::thread::id>` in daemon.hpp
- Updated all reads of `event_loop_thread_id_` to use `.load(std::memory_order_relaxed)` in `enqueue_control_task()`
- Updated all writes of `event_loop_thread_id_` to use `.store(..., std::memory_order_relaxed)` in `run()`

## Implementation Details
- Uses `std::memory_order_relaxed` for all atomic operations since thread ID comparisons don't require synchronization with other atomic variables
- Maintains the same logical behavior while ensuring thread-safe access to the shared thread ID variable
- This prevents potential data races when the event loop thread ID is accessed from multiple threads

https://claude.ai/code/session_01HFTdAdpHUcraRUDoWVcLqh