### PR TITLE
Implement atomic cache downloads with temporary files

### DIFF
--- a/src/cache/cache_manager.cpp
+++ b/src/cache/cache_manager.cpp
@@ -55,11 +55,19 @@ bool CacheManager::download(const std::string& name, const std::string& url) {
         return false;
     }
 
-    std::filesystem::path path = cache_path(name);
+    std::filesystem::path final_path = cache_path(name);
+    std::filesystem::path final_meta = meta_path(name);
+    std::filesystem::path tmp_path = cache_dir_ / (name + ".txt.tmp");
+    std::filesystem::path tmp_meta = cache_dir_ / (name + ".meta.json.tmp");
+
     {
-        std::ofstream ofs(path, std::ios::binary);
+        std::ofstream ofs(tmp_path, std::ios::binary);
         if (!ofs) return false;
         ofs << result.body;
+        if (!ofs) {
+            std::filesystem::remove(tmp_path);
+            return false;
+        }
     }
 
     CacheMetadata meta;
@@ -67,7 +75,25 @@ bool CacheManager::download(const std::string& name, const std::string& url) {
     meta.last_modified = result.last_modified;
     meta.url = url;
     meta.download_time = current_time_iso();
-    save_metadata(name, meta);
+
+    {
+        std::ofstream ofs(tmp_meta);
+        if (!ofs) {
+            std::filesystem::remove(tmp_path);
+            return false;
+        }
+        ofs << nlohmann::json(meta).dump(2) << '\n';
+        if (!ofs) {
+            std::filesystem::remove(tmp_path);
+            std::filesystem::remove(tmp_meta);
+            return false;
+        }
+    }
+
+    // Rename body first: on crash here, old meta triggers a re-download (safe).
+    // Rename meta second: once both succeed the cache is fully consistent.
+    std::filesystem::rename(tmp_path, final_path);
+    std::filesystem::rename(tmp_meta, final_meta);
 
     return true;
 }


### PR DESCRIPTION
## Summary
Refactored the cache download process to use atomic file operations with temporary files, ensuring cache consistency even if the process crashes during download or metadata writing.

## Key Changes
- **Temporary file pattern**: Downloads now write to `.txt.tmp` and `.meta.json.tmp` files instead of directly to final locations
- **Two-phase commit**: Files are renamed to their final paths only after both the cache body and metadata are successfully written and flushed
- **Enhanced error handling**: Added explicit flush checks after writing file contents and cleanup of temporary files on failure
- **Crash-safe ordering**: Body file is renamed first, then metadata file, ensuring that if a crash occurs between renames, the old metadata will trigger a re-download (safe behavior)

## Implementation Details
- Metadata is now written inline during download instead of calling `save_metadata()`, allowing it to participate in the atomic operation
- All file write operations include error checking and proper cleanup of temporary files on failure
- The rename operations provide atomicity guarantees at the filesystem level, preventing partial or corrupted cache entries

https://claude.ai/code/session_01BhnBQ1GpM2TotQA9QWbs2E