### PR TITLE
Add thread-safe synchronization to UrltestManager

### DIFF
--- a/src/routing/urltest_manager.cpp
+++ b/src/routing/urltest_manager.cpp
@@ -20,6 +20,8 @@ UrltestManager::~UrltestManager() {
 }
 
 void UrltestManager::register_urltest(const Outbound& ut) {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+
     UrltestState state;
     state.config = ut;
 
@@ -41,18 +43,20 @@ void UrltestManager::register_urltest(const Outbound& ut) {
 
     states_.emplace(ut.tag, std::move(state));
 
-    // Run initial test immediately
-    run_tests(ut.tag);
+    // Run initial test immediately (lock already held)
+    run_tests_locked(ut.tag);
 }
 
 void UrltestManager::trigger_immediate_test(const std::string& urltest_tag) {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
     auto it = states_.find(urltest_tag);
     if (it != states_.end()) {
-        run_tests(urltest_tag);
+        run_tests_locked(urltest_tag);
     }
 }
 
 std::string UrltestManager::get_selected(const std::string& urltest_tag) const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
     auto it = states_.find(urltest_tag);
     if (it == states_.end()) {
         return "";
@@ -60,11 +64,13 @@ std::string UrltestManager::get_selected(const std::string& urltest_tag) const {
     return it->second.selected_outbound;
 }
 
-const UrltestState& UrltestManager::get_state(const std::string& urltest_tag) const {
+UrltestState UrltestManager::get_state(const std::string& urltest_tag) const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
     return states_.at(urltest_tag);
 }
 
 void UrltestManager::clear() {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
     for (auto& [tag, state] : states_) {
         if (state.scheduler_task_id >= 0) {
             scheduler_.cancel(state.scheduler_task_id);
@@ -74,6 +80,11 @@ void UrltestManager::clear() {
 }
 
 void UrltestManager::run_tests(const std::string& tag) {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    run_tests_locked(tag);
+}
+
+void UrltestManager::run_tests_locked(const std::string& tag) {
     auto it = states_.find(tag);
     if (it == states_.end()) return;
 

--- a/src/routing/urltest_manager.hpp
+++ b/src/routing/urltest_manager.hpp
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <map>
+#include <shared_mutex>
 #include <string>
 
 namespace keen_pbr3 {
@@ -47,25 +48,31 @@ public:
     // Returns empty string if not registered or no outbound selected.
     std::string get_selected(const std::string& urltest_tag) const;
 
-    // Get const reference to state for API/status reporting.
+    // Get a snapshot of state for API/status reporting.
     // Throws std::out_of_range if tag not found.
-    const UrltestState& get_state(const std::string& urltest_tag) const;
+    UrltestState get_state(const std::string& urltest_tag) const;
 
     // Unregister all urltest outbounds and cancel their scheduled tasks.
     void clear();
 
 private:
     // Run URL tests for all child outbounds of the given urltest and update selection.
+    // Acquires unique_lock on mutex_.
     void run_tests(const std::string& tag);
+
+    // Internal implementation of run_tests; caller must already hold unique_lock on mutex_.
+    void run_tests_locked(const std::string& tag);
 
     // Select the best outbound using weighted group algorithm with tolerance.
     // Returns empty string if all outbounds are circuit-broken (blackhole fallback).
+    // Caller must hold at least a shared_lock on mutex_.
     std::string select_outbound(const std::string& tag);
 
     URLTester& tester_;
     const OutboundMarkMap& marks_;
     Scheduler& scheduler_;
     UrltestChangeCallback on_change_;
+    mutable std::shared_mutex mutex_;
     std::map<std::string, UrltestState> states_;
 };
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive thread-safety to the `UrltestManager` class by introducing a `shared_mutex` to protect access to the internal `states_` map. This ensures safe concurrent access from multiple threads.

## Key Changes
- **Added `shared_mutex` protection**: Introduced `mutable std::shared_mutex mutex_` to synchronize access to the `states_` map
- **Locked all public methods**: Added appropriate lock acquisition in all public methods:
  - `register_urltest()`: Uses unique_lock for write access
  - `trigger_immediate_test()`: Uses unique_lock for write access
  - `get_selected()`: Uses shared_lock for read-only access
  - `get_state()`: Uses shared_lock for read-only access
  - `clear()`: Uses unique_lock for write access
- **Refactored `run_tests()` method**: Split into two versions:
  - `run_tests()`: Public method that acquires unique_lock and delegates to `run_tests_locked()`
  - `run_tests_locked()`: Private method for internal use when lock is already held
- **Changed `get_state()` return type**: Changed from returning `const UrltestState&` to returning `UrltestState` by value to avoid dangling references and simplify lifetime management with the new locking scheme
- **Updated documentation**: Added comments clarifying lock requirements for internal methods

## Implementation Details
- Uses `shared_lock` for read-only operations (`get_selected()`, `get_state()`) to allow concurrent readers
- Uses `unique_lock` for write operations to ensure exclusive access
- The `run_tests_locked()` private method allows internal callers to avoid recursive locking when they already hold the lock
- All lock acquisitions are scoped to minimize contention

https://claude.ai/code/session_016ZtCZgDTUeoQk6ukUacDjc