### PR TITLE
Replace send() with write() in safe_exec pipe handling

### DIFF
--- a/src/util/safe_exec.hpp
+++ b/src/util/safe_exec.hpp
@@ -4,7 +4,6 @@
 #include <signal.h>
 #include <fcntl.h>
 #include <string>
-#include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <vector>
@@ -84,7 +83,7 @@ inline int safe_exec_pipe_stdin(const std::vector<std::string>& args,
     const char* data = input.data();
     size_t remaining = input.size();
     while (remaining > 0) {
-        const ssize_t written = send(pipefd[1], data, remaining, MSG_NOSIGNAL);
+        const ssize_t written = write(pipefd[1], data, remaining);
         if (written < 0) {
             if (errno == EINTR) continue;
             break;


### PR DESCRIPTION
## Summary
Simplified pipe writing logic in `safe_exec_pipe_stdin()` by replacing `send()` with the standard `write()` function, and removed the now-unused `<sys/socket.h>` header.

## Changes
- Replaced `send(pipefd[1], data, remaining, MSG_NOSIGNAL)` with `write(pipefd[1], data, remaining)` for writing to the pipe
- Removed `#include <sys/socket.h>` header as it is no longer needed

## Implementation Details
The `write()` function is more appropriate for file descriptor operations (including pipes) compared to `send()`, which is primarily intended for socket operations. This change maintains the same error handling logic (checking for `EINTR` and breaking on other errors) while using a more idiomatic approach for pipe I/O operations.

https://claude.ai/code/session_01LSFnUsT7oueW3FdPuH55Rk