### PR TITLE
Add GitHub Actions workflow to publish docs to gh-pages

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,38 @@
+name: Publish docs to gh-pages
+
+on:
+  push:
+    branches:
+      - main
+      - dev-3.0
+    paths:
+      - 'docs/**'
+
+permissions:
+  contents: write
+
+jobs:
+  publish-docs:
+    name: Build and publish docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: 'latest'
+          extended: true
+
+      - name: Build docs
+        run: hugo --source docs --destination ../site
+
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./site
+          force_orphan: true


### PR DESCRIPTION
### Motivation
- Automatically build and publish the Hugo documentation when files under `docs/**` change on the `main` and `dev-3.0` branches so the `gh-pages` branch root contains up-to-date static docs.

### Description
- Add `.github/workflows/publish-docs.yml` which triggers on pushes to `main` and `dev-3.0` filtered to `docs/**`, sets up Hugo with `peaceiris/actions-hugo@v3`, builds the site from `docs/` to `./site`, and deploys the generated files to the `gh-pages` branch root using `peaceiris/actions-gh-pages@v4` with `force_orphan: true`.

### Testing
- Created and committed the workflow file and verified repository changes with `git status --short` and `git show --stat --oneline -1`, both of which completed successfully; no CI workflow run has been observed yet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d18e3cd350832a9900155fd9f78602)