### PR TITLE
docs: update config examples for valid list names and dns.system_resolver

### DIFF
--- a/docs/content/docs/configuration/_index.md
+++ b/docs/content/docs/configuration/_index.md
@@ -84,27 +84,32 @@ The following is the full annotated example configuration:
   ],
 
   "lists": {
-    "my-domains": {
+    "my_domains": {
       "domains": ["example.com", "*.example.org"]
     },
-    "my-ips": {
+    "my_ips": {
       "ip_cidrs": ["93.184.216.34", "10.0.0.0/8"]
     },
-    "remote-list": {
+    "remote_list": {
       "url": "https://raw.githubusercontent.com/v2fly/domain-list-community/refs/heads/master/data/apple"
     },
-    "local-list": {
+    "local_list": {
       "file": "./my-list.txt"
     }
   },
 
   "dns": {
+    "system_resolver": {
+      "type": "dnsmasq-nftset",
+      "hook": "/usr/lib/keen-pbr/dnsmasq.sh",
+      "address": "127.0.0.1"
+    },
     "servers": [
       { "tag": "vpn-dns", "address": "10.8.0.1" },
       { "tag": "google-dns", "address": "8.8.8.8" }
     ],
     "rules": [
-      { "list": ["my-domains", "remote-list"], "server": "vpn-dns" }
+      { "list": ["my_domains", "remote_list"], "server": "vpn-dns" }
     ],
     "fallback": ["google-dns", "quad9"]
   },
@@ -125,13 +130,17 @@ The following is the full annotated example configuration:
 
   "route": {
     "rules": [
-      { "list": ["my-domains", "my-ips", "remote-list"], "outbound": "vpn" },
-      { "list": ["local-list"], "outbound": "auto-select" }
+      { "list": ["my_domains", "my_ips", "remote_list"], "outbound": "vpn" },
+      { "list": ["local_list"], "outbound": "auto-select" }
     ],
     "fallback": "wan"
   }
 }
 ```
+
+{{< callout type="info" >}}
+List names must be 1-24 characters, use only `a-z`, `A-Z`, `0-9`, and `_`, and the first character must be a letter (`[a-zA-Z][a-zA-Z0-9_]{0,23}`).
+{{< /callout >}}
 
 ## Sections
 

--- a/docs/content/docs/getting-started/quick-start.md
+++ b/docs/content/docs/getting-started/quick-start.md
@@ -30,14 +30,21 @@ Create `/etc/keen-pbr/config.json`:
     }
   ],
   "lists": {
-    "my-domains": {
+    "my_domains": {
       "domains": ["example.com", "*.example.org"]
+    }
+  },
+  "dns": {
+    "system_resolver": {
+      "type": "dnsmasq-nftset",
+      "hook": "/usr/lib/keen-pbr/dnsmasq.sh",
+      "address": "127.0.0.1"
     }
   },
   "route": {
     "rules": [
       {
-        "list": ["my-domains"],
+        "list": ["my_domains"],
         "outbound": "vpn"
       }
     ],
@@ -48,8 +55,9 @@ Create `/etc/keen-pbr/config.json`:
 
 This config:
 - Defines two outbounds: `vpn` (tun0) and `wan` (eth0)
-- Creates a list `my-domains` with two inline domain entries
-- Routes all traffic matching `my-domains` through `vpn`
+- Creates a list `my_domains` with two inline domain entries
+- Configures `dns.system_resolver` for dnsmasq integration
+- Routes all traffic matching `my_domains` through `vpn`
 - Falls back to `wan` for everything else
 
 ## Run the Daemon


### PR DESCRIPTION
### Motivation
- Prevent user copy-paste from producing invalid configs by aligning examples with runtime validation: list names must start with a letter, may contain letters/digits/underscore, and be <=24 chars. 
- Ensure examples include a valid `dns.system_resolver` block because the runtime requires it for dnsmasq integration and health checks.

### Description
- Updated `docs/content/docs/getting-started/quick-start.md` to add a `dns.system_resolver` example and renamed the inline list from `my-domains` to `my_domains`, updating the matching `route.rules[].list` reference and explanatory bullets. 
- Updated `docs/content/docs/configuration/_index.md` complete example to replace hyphenated list keys (`my-domains`, `my-ips`, `remote-list`, `local-list`) with valid identifiers (`my_domains`, `my_ips`, `remote_list`, `local_list`) and updated all corresponding entries in `dns.rules[].list` and `route.rules[].list`.
- Added a short callout note with the exact list naming constraints and the regex form: ``[a-zA-Z][a-zA-Z0-9_]{0,23}`` to make allowed charset and max length explicit.

### Testing
- Ran the repository `make` (root Makefile as required by project docs) to validate the tree; CMake configure failed due to a missing system package (`libnl-3.0`) in the environment, so a full build/test cycle could not complete. 
- No further automated tests were executed in this environment because the build did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2837804ec832a9490cd431d9bf5d6)