### PR TITLE
Update API default listen address to 0.0.0.0:12121

### DIFF
--- a/docs/content/docs/api/_index.md
+++ b/docs/content/docs/api/_index.md
@@ -18,12 +18,12 @@ The API is available when:
 {
   "api": {
     "enabled": true,
-    "listen": "127.0.0.1:8080"
+    "listen": "0.0.0.0:12121"
   }
 }
 ```
 
-The default listen address is `127.0.0.1:8080`. To expose the API on all interfaces, use `0.0.0.0:8080`.
+The default listen address is `0.0.0.0:12121`.
 
 ## Endpoints
 

--- a/docs/content/docs/api/endpoints.md
+++ b/docs/content/docs/api/endpoints.md
@@ -3,7 +3,7 @@ title: Endpoints
 weight: 1
 ---
 
-All endpoints are served at the configured `api.listen` address (default `127.0.0.1:8080`).
+All endpoints are served at the configured `api.listen` address (default `0.0.0.0:12121`).
 
 ---
 
@@ -12,7 +12,7 @@ All endpoints are served at the configured `api.listen` address (default `127.0.
 Returns the running daemon version, routing runtime status, and resolver configuration summary.
 
 ```bash
-curl http://127.0.0.1:8080/api/health/service
+curl http://127.0.0.1:12121/api/health/service
 ```
 
 ### Response
@@ -38,7 +38,7 @@ For live outbound runtime state (health, latency, circuit breaker) use `GET /api
 Returns the current configuration together with a flag indicating whether it is a staged in-memory draft.
 
 ```bash
-curl http://127.0.0.1:8080/api/config
+curl http://127.0.0.1:12121/api/config
 ```
 
 ### Response
@@ -47,7 +47,7 @@ curl http://127.0.0.1:8080/api/config
 {
   "config": {
     "daemon": { "pid_file": "/var/run/keen-pbr.pid", "cache_dir": "/var/cache/keen-pbr" },
-    "api": { "enabled": true, "listen": "127.0.0.1:8080" },
+    "api": { "enabled": true, "listen": "127.0.0.1:12121" },
     "outbounds": [],
     "lists": {},
     "route": {}
@@ -73,7 +73,7 @@ curl http://127.0.0.1:8080/api/config
 Validates the provided JSON body as a config file and stages it in daemon memory. The config is **not** written to disk and the routing runtime is **not** changed. Use `POST /api/config/save` to persist and apply the staged draft.
 
 ```bash
-curl -X POST http://127.0.0.1:8080/api/config \
+curl -X POST http://127.0.0.1:12121/api/config \
   -H "Content-Type: application/json" \
   -d @new-config.json
 ```
@@ -105,7 +105,7 @@ curl -X POST http://127.0.0.1:8080/api/config \
 Persists the currently staged in-memory config to disk, then applies it to the routing runtime.
 
 ```bash
-curl -X POST http://127.0.0.1:8080/api/config/save
+curl -X POST http://127.0.0.1:12121/api/config/save
 ```
 
 ### Response
@@ -138,7 +138,7 @@ curl -X POST http://127.0.0.1:8080/api/config/save
 Returns the daemon's current outbound runtime state: live urltest selection, interface reachability, and circuit breaker status.
 
 ```bash
-curl http://127.0.0.1:8080/api/runtime/outbounds
+curl http://127.0.0.1:12121/api/runtime/outbounds
 ```
 
 ### Response
@@ -171,7 +171,7 @@ curl http://127.0.0.1:8080/api/runtime/outbounds
 Resolves the target (if a domain), scans configured route rules against cached list data to determine the expected outbound, and queries the live kernel firewall sets to determine the actual outbound. Useful for diagnosing routing mismatches without restarting the daemon.
 
 ```bash
-curl -X POST http://127.0.0.1:8080/api/routing/test \
+curl -X POST http://127.0.0.1:12121/api/routing/test \
   -H "Content-Type: application/json" \
   -d '{"target": "example.com"}'
 ```
@@ -202,7 +202,7 @@ curl -X POST http://127.0.0.1:8080/api/routing/test \
 Verifies the live kernel routing and firewall state against the expected configuration. Checks that the firewall chain exists, all rules are present, route tables are populated, and policy rules are in place.
 
 ```bash
-curl http://127.0.0.1:8080/api/health/routing
+curl http://127.0.0.1:12121/api/health/routing
 ```
 
 ### Response
@@ -278,7 +278,7 @@ curl http://127.0.0.1:8080/api/health/routing
 Streams DNS queries observed by the built-in `dns.test_server` listener as Server-Sent Events. Each event payload is a JSON object. The connection receives a `HELLO` event immediately, then one `DNS` event per queried name while the connection is open.
 
 ```bash
-curl -N http://127.0.0.1:8080/api/dns/test
+curl -N http://127.0.0.1:12121/api/dns/test
 ```
 
 ### Stream Example

--- a/docs/content/docs/configuration/advanced.md
+++ b/docs/content/docs/configuration/advanced.md
@@ -38,13 +38,13 @@ Controls the embedded HTTP API server.
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `enabled` | boolean | `false` | Enable the HTTP API |
-| `listen` | string | `"127.0.0.1:8080"` | Address and port to listen on |
+| `listen` | string | `"0.0.0.0:12121"` | Address and port to listen on |
 
 ```json
 {
   "api": {
     "enabled": true,
-    "listen": "127.0.0.1:8080"
+    "listen": "0.0.0.0:12121"
   }
 }
 ```

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -163,7 +163,7 @@ struct ApiServer::Impl {
 
 ApiServer::ApiServer(const ApiConfig& config) : impl_(std::make_unique<Impl>()) {
     // Parse "host:port" from config.listen
-    const std::string listen = config.listen.value_or("0.0.0.0:8080");
+    const std::string listen = config.listen.value_or("0.0.0.0:12121");
     auto colon = listen.rfind(':');
     if (colon == std::string::npos) {
         throw ApiError("Invalid listen address: " + listen +

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1404,7 +1404,7 @@ void Daemon::setup_api() {
         Logger::instance().info("Frontend static root: {}", frontend_root.string());
     }
 
-    const std::string listen_addr = config_.api->listen.value_or("0.0.0.0:8080");
+    const std::string listen_addr = config_.api->listen.value_or("0.0.0.0:12121");
     Logger::instance().info("Starting REST API on {}", listen_addr);
     try {
         api_server_->start();


### PR DESCRIPTION
### Motivation
- Align runtime default and documentation so the advertised `api.listen` matches the actual fallback used by the code.
- Change the default API listen address/port from the old `*:8080`/`127.0.0.1:8080` examples to `0.0.0.0:12121` as requested.

### Description
- Change the API server fallback listen address to `0.0.0.0:12121` in `src/api/server.cpp` (`ApiServer` constructor) and `src/daemon/daemon.cpp` (startup logging path). 
- Update documentation examples and defaults in `docs/content/docs/api/_index.md` and `docs/content/docs/configuration/advanced.md` to use `0.0.0.0:12121` for the `api.listen` value.
- Update all API endpoint curl examples and references in `docs/content/docs/api/endpoints.md` to use port `12121` instead of `8080`.

### Testing
- Ran the project build with `make`; CMake configuration failed in this environment because the system package `libnl-3.0` was not found, so a full build/test run could not be completed (configuration error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2840cd004832a84c5733a12b72a22)