### PR TITLE
docs(api): document POST /api/lists/refresh endpoint

### DIFF
--- a/docs/content/docs/api/_index.md
+++ b/docs/content/docs/api/_index.md
@@ -35,6 +35,7 @@ See [Endpoints](endpoints/) for full documentation of all available endpoints.
 | `POST` | `/api/service/start` | Start the routing runtime |
 | `POST` | `/api/service/stop` | Stop the routing runtime |
 | `POST` | `/api/service/restart` | Restart the routing runtime |
+| `POST` | `/api/lists/refresh` | Refresh one URL-backed list (or all URL-backed lists) and reload runtime if relevant data changed |
 | `GET` | `/api/config` | Get current config as JSON |
 | `POST` | `/api/config` | Validate and stage config in memory |
 | `POST` | `/api/config/save` | Persist and apply the staged config |

--- a/docs/content/docs/api/endpoints.md
+++ b/docs/content/docs/api/endpoints.md
@@ -33,6 +33,71 @@ For live outbound runtime state (health, latency, circuit breaker) use `GET /api
 
 ---
 
+## POST /api/lists/refresh
+
+Refreshes remote URL-backed lists from the active daemon config.
+
+- If `name` is provided, only that URL-backed list is refreshed.
+- If `name` is omitted, all URL-backed lists are refreshed.
+- If refreshed data changed and affects active routing/DNS while the runtime is running, keen-pbr rebuilds runtime state so updates take effect immediately.
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/lists/refresh \
+  -H "Content-Type: application/json" \
+  -d '{"name":"apple"}'
+```
+
+Refresh all URL-backed lists:
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/lists/refresh
+```
+
+### Request Body (optional)
+
+```json
+{
+  "name": "apple"
+}
+```
+
+- `name` *(optional string)*: List name to refresh. When omitted, all URL-backed lists from the active config are refreshed.
+
+### Response (200)
+
+```json
+{
+  "status": "ok",
+  "message": "Lists refreshed and runtime reloaded",
+  "refreshed_lists": ["apple", "google"],
+  "changed_lists": ["apple"],
+  "reloaded": true
+}
+```
+
+Success payload fields:
+
+- `refreshed_lists` *(array[string])*: URL-backed lists that were refreshed.
+- `changed_lists` *(array[string])*: Refreshed lists whose cached contents changed.
+- `reloaded` *(boolean)*: Whether the running routing runtime was rebuilt because relevant changed lists were in active use.
+
+### Status / Error Behavior
+
+- `200`: Refresh operation completed.
+- `400`: Requested list exists but is not URL-backed.
+- `404`: Requested list not found.
+- `409`: Refresh rejected because a staged draft exists or another config/runtime operation is already in progress.
+
+Error response body:
+
+```json
+{
+  "error": "human-readable message"
+}
+```
+
+---
+
 ## GET /api/config
 
 Returns the current configuration together with a flag indicating whether it is a staged in-memory draft.


### PR DESCRIPTION
### Motivation

- Ensure the API documentation matches the implemented `POST /api/lists/refresh` handler and explains request/response semantics and runtime reload behavior.

### Description

- Added a summary table entry for `POST /api/lists/refresh` in `docs/content/docs/api/_index.md` describing refresh + conditional runtime reload behavior.
- Added a full `POST /api/lists/refresh` section to `docs/content/docs/api/endpoints.md` with example `curl` calls, an optional request body (`name`), and a sample success payload.
- Documented success payload fields `refreshed_lists`, `changed_lists`, and `reloaded` and described their meanings.
- Documented status and error behavior for `200`, `400`, `404`, and `409` responses and included an example error body.

### Testing

- Ran `make` as an automated validation step, which failed during CMake configuration due to a missing system package (`libnl-3.0`), so a full build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d284238f60832ab3996ab6d7febd50)