### PR TITLE
api: classify routing test invalid bodies as 400 errors

### DIFF
--- a/src/api/handler_test_routing.cpp
+++ b/src/api/handler_test_routing.cpp
@@ -5,7 +5,6 @@
 #include "generated/api_types.hpp"
 
 #include <nlohmann/json.hpp>
-#include <stdexcept>
 
 namespace keen_pbr3 {
 
@@ -14,17 +13,17 @@ void register_test_routing_handler(ApiServer& server, ApiContext& ctx) {
         nlohmann::json j;
         try {
             j = nlohmann::json::parse(body);
-        } catch (...) {
-            throw std::runtime_error(
-                nlohmann::json{{"error", "invalid JSON body"}}.dump());
+        } catch (const nlohmann::json::exception&) {
+            nlohmann::json payload = {{"error", "Invalid request body"}};
+            throw ApiError("Invalid request body", 400, payload.dump());
         }
 
         api::RoutingTestRequest req;
         try {
             api::from_json(j, req);
-        } catch (const std::exception& e) {
-            throw std::runtime_error(
-                nlohmann::json{{"error", std::string("invalid request: ") + e.what()}}.dump());
+        } catch (const std::exception&) {
+            nlohmann::json payload = {{"error", "Invalid request body"}};
+            throw ApiError("Invalid request body", 400, payload.dump());
         }
 
         auto result = ctx.compute_test_routing(req.target);


### PR DESCRIPTION
### Motivation
- Ensure client-side problems when calling `/api/routing/test` (malformed JSON or wrong request shape) are classified as HTTP 400 client errors and returned in the standard error response shape per `docs/openapi.yaml`.

### Description
- Replace `std::runtime_error` usage in `src/api/handler_test_routing.cpp` with `ApiError("Invalid request body", 400, ...)`, standardize the JSON payload to `{ "error": "Invalid request body" }`, and remove the now-unused `#include <stdexcept>`.

### Testing
- Ran the project build with `make` from the repo root, which exercised CMake configuration but failed in this environment due to a missing system package (`libnl-3.0`) during configure, so no successful binary test was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2843327a4832abf1df7858f25d257)