### PR TITLE
api: return structured 500 error for routing health failures

### DIFF
--- a/src/api/handler_health_routing.cpp
+++ b/src/api/handler_health_routing.cpp
@@ -4,7 +4,6 @@
 #include "generated/api_types.hpp"
 
 #include <nlohmann/json.hpp>
-#include <stdexcept>
 
 #include "../health/routing_health_checker.hpp"
 
@@ -22,8 +21,7 @@ void register_health_routing_handler(ApiServer& server, ApiContext& ctx) {
             api::RoutingHealthErrorResponse err;
             err.error = e.what();
             err.overall = api::RoutingHealthErrorResponseOverall::ERROR;
-            // Re-throw so the server wrapper sets HTTP 500
-            throw std::runtime_error(nlohmann::json(err).dump());
+            throw ApiError("Routing health check failed", 500, nlohmann::json(err).dump());
         }
     });
 }


### PR DESCRIPTION
### Motivation
- Ensure the API returns a structured JSON error object (with `overall` and `error` fields) and HTTP `500` when the routing health check throws, instead of embedding JSON inside a `std::runtime_error` message.

### Description
- In `src/api/handler_health_routing.cpp` replace the `std::runtime_error` rethrow with `throw ApiError("Routing health check failed", 500, nlohmann::json(err).dump());` and remove the now-unneeded `#include <stdexcept>`, so the response body is a serialized `api::RoutingHealthErrorResponse` object.

### Testing
- Ran `make` from the repository root which failed during CMake configuration due to a missing system dependency (`libnl-3.0`), so a full build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2843e4338832a87ef468a380c1bd3)