### PR TITLE
docs: normalize DNS test_server → dns_test_server

### DIFF
--- a/docs/content/docs/api/endpoints.md
+++ b/docs/content/docs/api/endpoints.md
@@ -275,7 +275,7 @@ curl http://127.0.0.1:8080/api/health/routing
 
 ## GET /api/dns/test
 
-Streams DNS queries observed by the built-in `dns.test_server` listener as Server-Sent Events. Each event payload is a JSON object. The connection receives a `HELLO` event immediately, then one `DNS` event per queried name while the connection is open.
+Streams DNS queries observed by the built-in `dns.dns_test_server` listener as Server-Sent Events. Each event payload is a JSON object. The connection receives a `HELLO` event immediately, then one `DNS` event per queried name while the connection is open.
 
 ```bash
 curl -N http://127.0.0.1:8080/api/dns/test

--- a/docs/content/docs/configuration/dns.md
+++ b/docs/content/docs/configuration/dns.md
@@ -10,7 +10,7 @@ keen-pbr integrates with dnsmasq to route DNS queries for specific domain lists 
 ```json
 {
   "dns": {
-    "test_server": {
+    "dns_test_server": {
       "listen": "127.0.0.88:53"
     },
     "servers": [...],
@@ -25,7 +25,7 @@ keen-pbr integrates with dnsmasq to route DNS queries for specific domain lists 
 | `servers` | array | DNS server definitions |
 | `rules` | array | Rules mapping lists to DNS servers |
 | `fallback` | array of string | Ordered DNS server tags for queries that match no rule |
-| `test_server` | object | Optional built-in DNS probe listener for connectivity checks |
+| `dns_test_server` | object | Optional built-in DNS probe listener for connectivity checks |
 
 ## System Resolver
 
@@ -44,7 +44,7 @@ daemon runtime.
 
 ## DNS Test Server
 
-`dns.test_server` enables a minimal DNS server inside keen-pbr. It listens on
+`dns.dns_test_server` enables a minimal DNS server inside keen-pbr. It listens on
 the configured IPv4 `host:port`, accepts both UDP and TCP DNS requests, logs
 the queried name, and always replies with one synthetic `A` record.
 
@@ -56,7 +56,7 @@ the queried name, and always replies with one synthetic `A` record.
 ```json
 {
   "dns": {
-    "test_server": {
+    "dns_test_server": {
       "listen": "127.0.0.88:53"
     }
   }


### PR DESCRIPTION
### Motivation
- Align documentation with the generated API types and daemon runtime which expect `dns_test_server` instead of `test_server` so examples and dotted-path references are consistent.

### Description
- Replaced `test_server`/`dns.test_server` with `dns_test_server`/`dns.dns_test_server` in docs and JSON snippets in `docs/content/docs/configuration/dns.md` and updated the `/api/dns/test` reference in `docs/content/docs/api/endpoints.md` to match.

### Testing
- Verified no remaining occurrences with `rg -n "dns\.test_server|\btest_server\b" docs/content/docs` and confirmed matches for the new key with `rg -n "dns_test_server|dns\.dns_test_server" docs/content/docs`.
- Attempted `make` but CMake configure failed in this environment due to missing `libnl-3.0`, so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d284744f70832ab9c616965d336388)