### PR TITLE
docs: remove outdated reference to Meson `firewall_backend` option in FAQ

### DIFF
--- a/docs/content/docs/troubleshooting/faq.md
+++ b/docs/content/docs/troubleshooting/faq.md
@@ -5,7 +5,7 @@ weight: 1
 
 ## What firewall backend will be used?
 
-keen-pbr auto-detects the firewall backend at startup. It uses nftables if available, and falls back to iptables/ipset on older kernels. You can override this at build time with the `firewall_backend` Meson option.
+keen-pbr auto-detects the firewall backend at startup. It uses nftables if available, and falls back to iptables/ipset on older kernels.
 
 ## How do I reload lists without restarting the daemon?
 


### PR DESCRIPTION
### Motivation
- Remove an outdated reference to the `firewall_backend` Meson build option from the FAQ because the option is no longer applicable and can confuse readers.

### Description
- Deleted the sentence in `docs/content/docs/troubleshooting/faq.md` that advised overriding the firewall backend with the `firewall_backend` Meson option.

### Testing
- Built the documentation site with `hugo` to verify rendering of the updated `faq.md`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2844617fc832abc2f0bd027a77287)