### PR TITLE
Remove remounting `key` from ListForm to preserve form state

### DIFF
--- a/frontend/src/pages/list-upsert-page.tsx
+++ b/frontend/src/pages/list-upsert-page.tsx
@@ -163,7 +163,6 @@ export function ListUpsertPage({
       ) : null}
 
       <ListForm
-        key={getListFormKey(mode, draft ?? sampleNewList)}
         apiErrorMessage={mutationErrorMessage}
         draft={draft ?? sampleNewList}
         existingListNames={Object.keys(listsMap)}


### PR DESCRIPTION
### Motivation
- The `key={getListFormKey(mode, draft ?? sampleNewList)}` on `ListForm` caused React to remount the form when the key changed, which reset local form state and could disrupt user input during edits.

### Description
- Removed the `key` prop from `ListForm` in `frontend/src/pages/list-upsert-page.tsx` so the form no longer unmounts/remounts when `mode` or `draft` change.

### Testing
- Ran `yarn build` and the frontend typecheck/build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6183bcd34832abe7e69ba6717f35f)