### PR TITLE
Add per-DNS-rule allow_domain_rebinding with UI and dnsmasq rebind support

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -540,6 +540,14 @@ components:
           type: string
           description: DNS server tag to use for matched domains.
           example: "vpn-dns"
+        allow_domain_rebinding:
+          type: boolean
+          default: false
+          description: >
+            Allow DNS responses for matched domains to resolve to internal/private
+            network addresses (for example 10.0.0.0/8, 172.16.0.0/12,
+            192.168.0.0/16, and other local ranges).
+          example: false
 
     DnsTestServer:
       type: object

--- a/frontend/src/api/generated/model/dnsRule.ts
+++ b/frontend/src/api/generated/model/dnsRule.ts
@@ -11,4 +11,7 @@ export interface DnsRule {
   list: string[];
   /** DNS server tag to use for matched domains. */
   server: string;
+  /** Allow DNS responses for matched domains to resolve to internal/private network addresses (for example 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, and other local ranges).
+   */
+  allow_domain_rebinding?: boolean;
 }

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -633,7 +633,12 @@ export const enTranslation = {
           headers: {
             lists: "Lists",
             serverTag: "DNS server",
+            allowDomainRebinding: "Domain rebinding",
             actions: "Actions",
+          },
+          rebinding: {
+            enabled: "Allowed",
+            disabled: "Blocked",
           },
         },
         dnsRuleUpsert: {
@@ -664,6 +669,9 @@ export const enTranslation = {
             dnsServers: "DNS servers",
             noServers: "No DNS servers defined on the DNS Servers page.",
             listNames: "List names",
+            allowDomainRebinding: "Allow domain rebinding for these domains",
+            allowDomainRebindingHint:
+              "Enable this only when you know this domain list points to internal services. Responses for matched domains will be allowed to contain internal/private IPs (for example 192.168.0.0/16, 10.0.0.0/8, and other local network ranges).",
             listPlaceholderDescription:
               "Choose which lists this rule applies to. Matching domains will use this DNS server.",
             noListsSelected: "No lists selected",

--- a/frontend/src/i18n/ru.ts
+++ b/frontend/src/i18n/ru.ts
@@ -650,7 +650,12 @@ export const ruTranslation = {
           headers: {
             lists: "Списки",
             serverTag: "DNS-сервер",
+            allowDomainRebinding: "Разрешение rebind",
             actions: "Действия",
+          },
+          rebinding: {
+            enabled: "Разрешён",
+            disabled: "Запрещён",
           },
         },
         dnsRuleUpsert: {
@@ -684,6 +689,9 @@ export const ruTranslation = {
             dnsServers: "DNS-серверы",
             noServers: "В config.dns.servers не определены DNS-серверы.",
             listNames: "Имена списков",
+            allowDomainRebinding: "Разрешить DNS rebind для этих доменов",
+            allowDomainRebindingHint:
+              "Включайте только если вы точно знаете, что этот список доменов указывает на внутренние сервисы. Тогда ответы для подходящих доменов могут содержать внутренние/приватные IP-адреса (например, 192.168.0.0/16, 10.0.0.0/8 и другие диапазоны локальной сети).",
             listPlaceholderDescription:
               "Выберите списки для этого правила. Совпадающие домены будут использовать этот DNS-сервер.",
             noListsSelected: "Списки не выбраны",

--- a/frontend/src/pages/dns-rule-upsert-page.tsx
+++ b/frontend/src/pages/dns-rule-upsert-page.tsx
@@ -21,6 +21,7 @@ import { MultiSelectList } from "@/components/shared/multi-select-list"
 import { UpsertPage } from "@/components/shared/upsert-page"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   applyFormApiErrors,
   clearFormServerErrors,
@@ -107,6 +108,7 @@ export function DnsRuleUpsertPage({
     rule: {
       server: serverTags[0] ?? "",
       lists: [],
+      allowDomainRebinding: false,
     },
   }
 
@@ -180,6 +182,7 @@ export function DnsRuleUpsertPage({
       rule: {
         server: serverTags[0] ?? "",
         lists: [],
+        allowDomainRebinding: false,
       },
     })
     clearFormServerErrors(form)
@@ -300,6 +303,35 @@ export function DnsRuleUpsertPage({
               </Field>
             )}
           </form.Field>
+
+          <form.Field name="rule.allowDomainRebinding">
+            {(field) => (
+              <Field>
+                <FieldContent>
+                  <div className="flex items-center space-x-3">
+                    <Checkbox
+                      checked={field.state.value}
+                      id="allow-domain-rebinding"
+                      onCheckedChange={(checked) =>
+                        field.handleChange(checked === true)
+                      }
+                    />
+                    <FieldLabel
+                      className="cursor-pointer flex-col items-start gap-0"
+                      htmlFor="allow-domain-rebinding"
+                    >
+                      {t("pages.dnsRuleUpsert.fields.allowDomainRebinding")}
+                    </FieldLabel>
+                  </div>
+                  <FieldHint
+                    description={t(
+                      "pages.dnsRuleUpsert.fields.allowDomainRebindingHint"
+                    )}
+                  />
+                </FieldContent>
+              </Field>
+            )}
+          </form.Field>
         </FieldGroup>
 
         {mutationErrorMessage ? (
@@ -355,6 +387,10 @@ function resolveDnsRuleFieldPath(path: string) {
 
   if (/^dns\.rules(?:\[\d+\]|\.\d+)?\.(list|lists)$/.test(path)) {
     return "rule.lists"
+  }
+
+  if (/^dns\.rules(?:\[\d+\]|\.\d+)?\.allow_domain_rebinding$/.test(path)) {
+    return "rule.allowDomainRebinding"
   }
 
   return undefined

--- a/frontend/src/pages/dns-rules-page.tsx
+++ b/frontend/src/pages/dns-rules-page.tsx
@@ -182,6 +182,7 @@ export function DnsRulesPage() {
               headers={[
                 t("pages.dnsRules.headers.lists"),
                 t("pages.dnsRules.headers.serverTag"),
+                t("pages.dnsRules.headers.allowDomainRebinding"),
                 t("pages.dnsRules.headers.actions"),
               ]}
               rows={rules.map((rule, index) => [
@@ -195,6 +196,14 @@ export function DnsRulesPage() {
                 <span className="font-medium" key={`server-${index}`}>
                   {rule.server}
                 </span>,
+                <Badge
+                  key={`allow-domain-rebinding-${index}`}
+                  variant={rule.allow_domain_rebinding ? "default" : "outline"}
+                >
+                  {rule.allow_domain_rebinding
+                    ? t("pages.dnsRules.rebinding.enabled")
+                    : t("pages.dnsRules.rebinding.disabled")}
+                </Badge>,
                 <ActionButtons
                   actions={[
                     {

--- a/frontend/src/pages/dns-rules-utils.ts
+++ b/frontend/src/pages/dns-rules-utils.ts
@@ -4,6 +4,7 @@ import i18n from "@/i18n"
 export type DnsRuleDraft = {
   server: string
   lists: string[]
+  allowDomainRebinding: boolean
 }
 
 export type RuleErrors = {
@@ -15,10 +16,12 @@ export type RuleErrors = {
 export function getRuleDraft(rule?: {
   server?: string
   list?: string[]
+  allow_domain_rebinding?: boolean
 }): DnsRuleDraft {
   return {
     server: rule?.server ?? "",
     lists: rule?.list ?? [],
+    allowDomainRebinding: rule?.allow_domain_rebinding ?? false,
   }
 }
 
@@ -35,6 +38,7 @@ export function buildUpdatedConfigWithRules(
       rules: rules.map((rule) => ({
         server: rule.server,
         list: rule.lists,
+        allow_domain_rebinding: rule.allowDomainRebinding,
       })),
     },
   }

--- a/src/api/generated/api_types.hpp
+++ b/src/api/generated/api_types.hpp
@@ -7,7 +7,7 @@
 //
 //  Then include this file, and then do
 //
-//     KeenPbrTypesRkDl3E data = nlohmann::json::parse(jsonString);
+//     KeenPbrTypesSuujvA data = nlohmann::json::parse(jsonString);
 
 #pragma once
 
@@ -128,6 +128,7 @@ namespace api {
     };
 
     struct DnsRuleElement {
+        std::optional<bool> allow_domain_rebinding;
         std::vector<std::string> list;
         std::string server;
     };
@@ -421,7 +422,7 @@ namespace api {
         std::vector<RuntimeOutboundStateElement> outbounds;
     };
 
-    struct KeenPbrTypesRkDl3E {
+    struct KeenPbrTypesSuujvA {
         std::optional<ApiConfig> api_config;
         std::optional<CacheMetadata> cache_metadata;
         std::optional<CheckStatus> check_status;
@@ -604,8 +605,8 @@ namespace api {
     void from_json(const json & j, RuntimeOutboundsResponse & x);
     void to_json(json & j, const RuntimeOutboundsResponse & x);
 
-    void from_json(const json & j, KeenPbrTypesRkDl3E & x);
-    void to_json(json & j, const KeenPbrTypesRkDl3E & x);
+    void from_json(const json & j, KeenPbrTypesSuujvA & x);
+    void to_json(json & j, const KeenPbrTypesSuujvA & x);
 
     void from_json(const json & j, CheckStatus & x);
     void to_json(json & j, const CheckStatus & x);
@@ -719,12 +720,14 @@ namespace api {
     }
 
     inline void from_json(const json & j, DnsRuleElement& x) {
+        x.allow_domain_rebinding = get_stack_optional<bool>(j, "allow_domain_rebinding");
         x.list = j.at("list").get<std::vector<std::string>>();
         x.server = j.at("server").get<std::string>();
     }
 
     inline void to_json(json & j, const DnsRuleElement & x) {
         j = json::object();
+        j["allow_domain_rebinding"] = x.allow_domain_rebinding;
         j["list"] = x.list;
         j["server"] = x.server;
     }
@@ -1300,7 +1303,7 @@ namespace api {
         j["outbounds"] = x.outbounds;
     }
 
-    inline void from_json(const json & j, KeenPbrTypesRkDl3E& x) {
+    inline void from_json(const json & j, KeenPbrTypesSuujvA& x) {
         x.api_config = get_stack_optional<ApiConfig>(j, "ApiConfig");
         x.cache_metadata = get_stack_optional<CacheMetadata>(j, "CacheMetadata");
         x.check_status = get_stack_optional<CheckStatus>(j, "CheckStatus");
@@ -1350,7 +1353,7 @@ namespace api {
         x.validation_error = get_stack_optional<ValidationErrorElement>(j, "ValidationError");
     }
 
-    inline void to_json(json & j, const KeenPbrTypesRkDl3E & x) {
+    inline void to_json(json & j, const KeenPbrTypesSuujvA & x) {
         j = json::object();
         j["ApiConfig"] = x.api_config;
         j["CacheMetadata"] = x.cache_metadata;

--- a/src/dns/dnsmasq_gen.cpp
+++ b/src/dns/dnsmasq_gen.cpp
@@ -149,10 +149,13 @@ void DnsmasqGenerator::generate_directives(std::ostream& out) {
     // Collect all list names referenced in DNS rules for server directives.
     // Map: list_name -> dns server tag
     std::map<std::string, std::string> dns_list_servers;
+    std::map<std::string, bool> dns_list_allow_rebind;
     for (const auto& rule : dns_config_.rules.value_or(std::vector<DnsRule>{})) {
         for (const auto& list_name : rule.list) {
             if (dns_list_servers.find(list_name) == dns_list_servers.end()) {
                 dns_list_servers[list_name] = rule.server;
+                dns_list_allow_rebind[list_name] =
+                    rule.allow_domain_rebinding.value_or(false);
             }
         }
     }
@@ -203,6 +206,9 @@ void DnsmasqGenerator::generate_directives(std::ostream& out) {
                 dns_port = server->port;
             }
         }
+        const bool allow_domain_rebinding =
+            dns_list_allow_rebind.find(list_name) != dns_list_allow_rebind.end()
+            && dns_list_allow_rebind[list_name];
 
         // Output domains in batches of ~BATCH_SIZE per directive line
         auto it = domains.begin();
@@ -225,6 +231,9 @@ void DnsmasqGenerator::generate_directives(std::ostream& out) {
                         << "/4#inet#KeenPbrTable#" << set4
                         << ",6#inet#KeenPbrTable#" << set6 << "\n";
                 }
+            }
+            if (allow_domain_rebinding) {
+                out << "rebind-domain-ok=" << domain_path << "/\n";
             }
             if (!dns_ip.empty()) {
                 std::string server_addr = dns_ip;

--- a/tests/test_dnsmasq_gen.cpp
+++ b/tests/test_dnsmasq_gen.cpp
@@ -42,13 +42,15 @@ static DnsConfig make_empty_dns_cfg() {
 // Build a DnsConfig with a single server and a rule mapping list_name to that server.
 static DnsConfig make_dns_cfg(const std::string& list_name,
                                const std::string& server_tag,
-                               const std::string& server_ip) {
+                               const std::string& server_ip,
+                               bool allow_domain_rebinding = false) {
     DnsServer srv;
     srv.tag     = server_tag;
     srv.address = server_ip;
     DnsRule rule;
     rule.list   = std::vector<std::string>{list_name};
     rule.server = server_tag;
+    rule.allow_domain_rebinding = allow_domain_rebinding;
     DnsConfig cfg;
     cfg.fallback = std::vector<std::string>{server_tag};
     cfg.servers  = std::vector<DnsServer>{srv};
@@ -376,6 +378,38 @@ TEST_CASE("generate-resolver-config omits dns probe server directive when disabl
 
     CHECK(output.find("rebind-domain-ok=keen.pbr\n") == std::string::npos);
     CHECK(output.find("server=/check.keen.pbr/") == std::string::npos);
+}
+
+TEST_CASE("generate-resolver-config includes rebind-domain-ok directives for dns rules with allow_domain_rebinding enabled") {
+    CacheManager cache("/nonexistent/cache");
+    ListStreamer streamer(cache);
+
+    const std::string list_name = "mylist";
+    auto route_cfg = make_route_cfg(list_name);
+    auto dns_cfg   = make_dns_cfg(list_name, "dns1", "8.8.8.8", true);
+    auto lists     = std::map<std::string, ListConfig>{{list_name, make_list_cfg({"example.com", "*.lan.test"})}};
+
+    DnsServerRegistry reg(dns_cfg);
+    DnsmasqGenerator gen(reg, streamer, route_cfg, dns_cfg, lists);
+    const std::string output = run_generate(gen);
+
+    CHECK(output.find("rebind-domain-ok=/example.com/lan.test/\n") != std::string::npos);
+}
+
+TEST_CASE("generate-resolver-config omits rebind-domain-ok directives for dns rules when allow_domain_rebinding is disabled") {
+    CacheManager cache("/nonexistent/cache");
+    ListStreamer streamer(cache);
+
+    const std::string list_name = "mylist";
+    auto route_cfg = make_route_cfg(list_name);
+    auto dns_cfg   = make_dns_cfg(list_name, "dns1", "8.8.8.8", false);
+    auto lists     = std::map<std::string, ListConfig>{{list_name, make_list_cfg({"example.com"})}};
+
+    DnsServerRegistry reg(dns_cfg);
+    DnsmasqGenerator gen(reg, streamer, route_cfg, dns_cfg, lists);
+    const std::string output = run_generate(gen);
+
+    CHECK(output.find("rebind-domain-ok=/example.com/\n") == std::string::npos);
 }
 
 TEST_CASE("hash changes when domain list content changes") {


### PR DESCRIPTION
### Motivation
- Introduce a per-DNS-rule option to permit DNS responses for matched domains to resolve to internal/private IP ranges (domain rebinding) so lists that point to internal services can be served correctly. 
- Ensure the new option is exposed in the API spec, frontend UI, types, and that the dnsmasq config generator emits corresponding `rebind-domain-ok` directives when enabled.

### Description
- Added `allow_domain_rebinding` to the OpenAPI schema (`docs/openapi.yaml`) and regenerated client/server types (`src/api/generated/api_types.hpp` and frontend model `frontend/src/api/generated/model/dnsRule.ts`).
- Frontend: added translations (`frontend/src/i18n/en.ts`, `frontend/src/i18n/ru.ts`), wired a checkbox field to the DNS rule upsert form (`frontend/src/pages/dns-rule-upsert-page.tsx`), included the flag in rule drafts and builders (`frontend/src/pages/dns-rules-utils.ts`), and surface the setting in the DNS rules list with a badge (`frontend/src/pages/dns-rules-page.tsx`).
- Backend: updated the dnsmasq config generator (`src/dns/dnsmasq_gen.cpp`) to record per-list rebinding flags and output `rebind-domain-ok` directives for lists whose rule has `allow_domain_rebinding=true`.
- Tests: extended the dnsmasq generator tests (`tests/test_dnsmasq_gen.cpp`) with cases asserting `rebind-domain-ok` is emitted when enabled and omitted when disabled.

### Testing
- Ran the C++ unit test suite that includes `tests/test_dnsmasq_gen.cpp` to validate dnsmasq output behavior, and the new tests passed. 
- Verified OpenAPI changes compile with regenerated types via the project codegen step (`make generate`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d61c26a70c832abbe2d939e6b78e13)