### PR TITLE
fix: keep resolver hash health fields populated across transient TXT query failures

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1366,8 +1366,6 @@ void Daemon::refresh_resolver_config_hash_actual_async() {
                         return;
                     }
 
-                    resolver_config_hash_actual_.clear();
-                    resolver_config_hash_actual_ts_.reset();
                     if (has_parsed_value) {
                         resolver_config_hash_actual_ = parsed_value.hash;
                         resolver_config_hash_actual_ts_ = parsed_value.ts;

--- a/src/dns/dns_txt_client.cpp
+++ b/src/dns/dns_txt_client.cpp
@@ -37,6 +37,21 @@ std::string trim_copy(const std::string& s) {
     return s.substr(begin, end - begin);
 }
 
+std::string strip_balanced_quotes(std::string value) {
+    value = trim_copy(value);
+    while (value.size() >= 2) {
+        const char first = value.front();
+        const char last = value.back();
+        const bool wrapped_by_double = (first == '"' && last == '"');
+        const bool wrapped_by_single = (first == '\'' && last == '\'');
+        if (!wrapped_by_double && !wrapped_by_single) {
+            break;
+        }
+        value = trim_copy(value.substr(1, value.size() - 2));
+    }
+    return value;
+}
+
 std::optional<std::string> parse_first_txt_answer(const unsigned char* response,
                                                   int response_len,
                                                   std::string* error_out) {
@@ -304,7 +319,7 @@ std::string normalize_dns_txt_md5(const std::string& txt_payload) {
 
 ResolverConfigHashTxtValue parse_resolver_config_hash_txt(const std::string& txt_payload) {
     ResolverConfigHashTxtValue value;
-    const std::string normalized = trim_copy(txt_payload);
+    const std::string normalized = strip_balanced_quotes(txt_payload);
 
     const size_t delimiter = normalized.find('|');
     if (delimiter == std::string::npos) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,10 @@ target_link_libraries(keen-pbr-tests PRIVATE
   fmt::fmt-header-only
 )
 
+if(LIBRESOLV)
+  target_link_libraries(keen-pbr-tests PRIVATE ${LIBRESOLV})
+endif()
+
 if(LIBATOMIC)
   target_link_libraries(keen-pbr-tests PRIVATE ${LIBATOMIC})
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(keen-pbr-tests
   test_cron.cpp
   test_addr_spec.cpp
   test_dnsmasq_gen.cpp
+  test_dns_txt_client.cpp
   test_dns_server.cpp
   test_keenetic_dns.cpp
   test_dns_probe_server.cpp
@@ -31,6 +32,7 @@ add_executable(keen-pbr-tests
   ../src/log/logger.cpp
   ../src/log/trace.cpp
   ../src/dns/dnsmasq_gen.cpp
+  ../src/dns/dns_txt_client.cpp
   ../src/dns/dns_router.cpp
   ../src/dns/dns_server.cpp
   ../src/dns/keenetic_dns.cpp

--- a/tests/test_dns_txt_client.cpp
+++ b/tests/test_dns_txt_client.cpp
@@ -1,0 +1,25 @@
+#include <doctest/doctest.h>
+
+#include "../src/dns/dns_txt_client.hpp"
+
+using namespace keen_pbr3;
+
+TEST_CASE("parse_resolver_config_hash_txt parses ts/hash payload") {
+    const auto parsed = parse_resolver_config_hash_txt("1744060800|0123456789abcdef0123456789abcdef");
+    REQUIRE(parsed.ts.has_value());
+    CHECK(*parsed.ts == 1744060800);
+    CHECK(parsed.hash == "0123456789abcdef0123456789abcdef");
+}
+
+TEST_CASE("parse_resolver_config_hash_txt parses quoted ts/hash payload") {
+    const auto parsed = parse_resolver_config_hash_txt("\"1744060800|0123456789abcdef0123456789abcdef\"");
+    REQUIRE(parsed.ts.has_value());
+    CHECK(*parsed.ts == 1744060800);
+    CHECK(parsed.hash == "0123456789abcdef0123456789abcdef");
+}
+
+TEST_CASE("parse_resolver_config_hash_txt parses md5-prefixed hash payload") {
+    const auto parsed = parse_resolver_config_hash_txt("md5=0123456789ABCDEF0123456789ABCDEF");
+    CHECK_FALSE(parsed.ts.has_value());
+    CHECK(parsed.hash == "0123456789abcdef0123456789abcdef");
+}


### PR DESCRIPTION
### Motivation
- `/api/health/service` was returning nulls for `resolver_config_hash_actual`, `resolver_config_hash_actual_ts` and `resolver_config_sync_state` because failed DNS TXT refresh attempts wiped the last-known values.
- Quoted TXT payloads like `"<ts>|<hash>"` were not normalized before splitting, which prevented timestamp extraction and therefore made `resolver_config_sync_state` remain null.

### Description
- Stop clearing `resolver_config_hash_actual_` and `resolver_config_hash_actual_ts_` on every TXT refresh commit path so transient TXT query failures do not regress the last-known resolver state (`src/daemon/daemon.cpp`).
- Add `strip_balanced_quotes()` and use it when parsing TXT payloads so quoted `<ts>|<hash>` payloads are normalized before splitting and timestamps are extracted reliably (`src/dns/dns_txt_client.cpp`).
- Add new unit tests covering plain ts/hash, quoted ts/hash, and `md5=` hash-only TXT payload variants in `tests/test_dns_txt_client.cpp` and include the test in `tests/CMakeLists.txt`.

### Testing
- Attempted to build with `make`, but CMake configure failed due to a missing pkg-config dependency `libnl-3.0`, so the test suite was not executed in this environment (configure error).
- New unit tests were added (`tests/test_dns_txt_client.cpp`) but were not run due to the build configure failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d66c457b40832a935c4d2e20dbcd29)