### PR TITLE
keen-pbr: avoid needless dnsmasq conf rewrites and remove temp confs on uninstall

### DIFF
--- a/packages/openwrt/keen-pbr/files/usr/lib/keen-pbr/dnsmasq.sh
+++ b/packages/openwrt/keen-pbr/files/usr/lib/keen-pbr/dnsmasq.sh
@@ -26,6 +26,22 @@ log_info() {
     log_message info "$1"
 }
 
+write_managed_conf() {
+    local target="$1"
+    local line="$2"
+    local existing=""
+
+    if [ -f "$target" ]; then
+        existing="$(cat "$target")"
+        if [ "$existing" = "$line" ]; then
+            return 0
+        fi
+    fi
+
+    printf '%s\n' "$line" > "$target"
+    log_info "Created $target"
+}
+
 resolver_type() {
     if command -v nft >/dev/null 2>&1; then
         echo "dnsmasq-nftset"
@@ -191,8 +207,7 @@ write_temp_conf_for_section() {
 
     confdir="$(dnsmasq_confdir "$section")"
     mkdir -p "$confdir"
-    printf '%s\n' "$(conf_script_line)" > "${confdir}/${CONFFILE}"
-    log_info "Created ${confdir}/${CONFFILE}"
+    write_managed_conf "${confdir}/${CONFFILE}" "$(conf_script_line)"
 }
 
 write_fallback_conf_for_section() {
@@ -202,8 +217,7 @@ write_fallback_conf_for_section() {
     confdir="$(dnsmasq_confdir "$section")"
     mkdir -p "$confdir"
     if [ -f "$DNSMASQ_FALLBACK_FILE" ]; then
-        printf '%s\n' "$(fallback_conf_line)" > "${confdir}/${CONFFILE}"
-        log_info "Created ${confdir}/${CONFFILE}"
+        write_managed_conf "${confdir}/${CONFFILE}" "$(fallback_conf_line)"
     else
         rm -f "${confdir}/${CONFFILE}"
         log_info "Removed ${confdir}/${CONFFILE}"
@@ -217,6 +231,16 @@ remove_temp_conf_for_section() {
     confdir="$(dnsmasq_confdir "$section")"
     rm -f "${confdir}/${CONFFILE}"
     log_info "Removed ${confdir}/${CONFFILE}"
+}
+
+remove_all_temp_confs() {
+    local path
+
+    for path in /tmp/dnsmasq.*.d/"${CONFFILE}" /tmp/dnsmasq.d/"${CONFFILE}"; do
+        [ -e "$path" ] || continue
+        rm -f "$path"
+        log_info "Removed $path"
+    done
 }
 
 install_persistent() {
@@ -296,6 +320,8 @@ uninstall_persistent() {
             log_info "Committed UCI package dhcp"
         fi
     fi
+
+    remove_all_temp_confs || true
 
     restart_dnsmasq
 }


### PR DESCRIPTION
### Motivation

- Prevent unnecessary file rewrites of helper-managed dnsmasq config files to reduce churn and avoid triggering needless service restarts. 
- Ensure helper-created temporary dnsmasq config files are cleaned up during uninstall to leave the system in a consistent state. 
- Centralize the logic for writing managed config lines to make intent and logging clearer.

### Description

- Added `write_managed_conf()` to write a single-line managed config only when the target differs from the existing content and to log creation. 
- Replaced direct `printf` writes in `write_temp_conf_for_section()` and `write_fallback_conf_for_section()` with `write_managed_conf()`. 
- Added `remove_all_temp_confs()` to remove helper-managed temp `CONFFILE` instances from `/tmp/dnsmasq.*.d/` and `/tmp/dnsmasq.d/`. 
- Invoke `remove_all_temp_confs()` from `uninstall_persistent()` and added logging for removals.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d66c5bf1b4832a8099452db89188b5)