### PR TITLE
Make firewall backend configurable via daemon.firewall_backend

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,7 @@
   "daemon": {
     "pid_file": "/var/run/keen-pbr.pid",
     "cache_dir": "/var/cache/keen-pbr",
+    "firewall_backend": "auto",
     "strict_enforcement": false
   },
 

--- a/docs/content/docs/configuration/advanced.md
+++ b/docs/content/docs/configuration/advanced.md
@@ -15,6 +15,7 @@ Controls the PID file path, cache directory, and global routing behaviour.
 |---|---|---|---|
 | `pid_file` | string | — | Path to write the PID file |
 | `cache_dir` | string | `/var/cache/keen-pbr` | Directory for cached list data |
+| `firewall_backend` | string | `"auto"` | Firewall backend selection: `auto`, `iptables`, or `nftables` |
 | `strict_enforcement` | boolean | `false` | Default strict routing enforcement for interface outbounds. When enabled, an unreachable default route is installed if the outbound gateway/interface cannot be confirmed reachable. Can be overridden per-outbound. |
 | `max_file_size_bytes` | integer | `8388608` (8 MiB) | Maximum allowed size in bytes for downloaded remote list content |
 | `firewall_verify_max_bytes` | integer | `262144` | Maximum stdout bytes captured per firewall verification command (`0` = unlimited) |
@@ -24,6 +25,7 @@ Controls the PID file path, cache directory, and global routing behaviour.
   "daemon": {
     "pid_file": "/var/run/keen-pbr.pid",
     "cache_dir": "/var/cache/keen-pbr",
+    "firewall_backend": "auto",
     "strict_enforcement": false,
     "max_file_size_bytes": 8388608,
     "firewall_verify_max_bytes": 262144

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -302,6 +302,12 @@ components:
           description: Directory for cached list data.
           default: "/var/cache/keen-pbr"
           example: "/var/cache/keen-pbr"
+        firewall_backend:
+          type: string
+          description: Firewall backend selection.
+          enum: [auto, iptables, nftables]
+          default: auto
+          example: auto
         firewall_verify_max_bytes:
           type: integer
           minimum: 0
@@ -735,6 +741,7 @@ components:
         daemon:
           pid_file: "/var/run/keen-pbr.pid"
           cache_dir: "/var/cache/keen-pbr"
+          firewall_backend: auto
           firewall_verify_max_bytes: 262144
           strict_enforcement: true
           max_file_size_bytes: 8388608

--- a/src/api/generated/api_types.hpp
+++ b/src/api/generated/api_types.hpp
@@ -116,6 +116,7 @@ namespace api {
 
     struct Daemon {
         std::optional<std::string> cache_dir;
+        std::optional<std::string> firewall_backend;
         std::optional<int64_t> firewall_verify_max_bytes;
         std::optional<int64_t> max_file_size_bytes;
         std::optional<std::string> pid_file;
@@ -693,6 +694,7 @@ namespace api {
 
     inline void from_json(const json & j, Daemon& x) {
         x.cache_dir = get_stack_optional<std::string>(j, "cache_dir");
+        x.firewall_backend = get_stack_optional<std::string>(j, "firewall_backend");
         x.firewall_verify_max_bytes = get_stack_optional<int64_t>(j, "firewall_verify_max_bytes");
         x.max_file_size_bytes = get_stack_optional<int64_t>(j, "max_file_size_bytes");
         x.pid_file = get_stack_optional<std::string>(j, "pid_file");
@@ -702,6 +704,7 @@ namespace api {
     inline void to_json(json & j, const Daemon & x) {
         j = json::object();
         j["cache_dir"] = x.cache_dir;
+        j["firewall_backend"] = x.firewall_backend;
         j["firewall_verify_max_bytes"] = x.firewall_verify_max_bytes;
         j["max_file_size_bytes"] = x.max_file_size_bytes;
         j["pid_file"] = x.pid_file;

--- a/src/cmd/status.cpp
+++ b/src/cmd/status.cpp
@@ -506,7 +506,7 @@ int run_status_command(const Config& config, const std::string& config_path) {
     fw_state.set_outbound_marks(marks);
     fw_state.set_rules(build_fw_rule_states(config, marks));
 
-    auto firewall = create_firewall("auto");
+    auto firewall = create_firewall(firewall_backend_preference(config));
     RoutingHealthChecker checker(*firewall, fw_state, routes, rules, netlink);
     RoutingHealthReport report = checker.check();
     const auto display_firewall_rules = build_display_firewall_rules(config, marks, report.firewall_rules);

--- a/src/cmd/test_routing.cpp
+++ b/src/cmd/test_routing.cpp
@@ -291,7 +291,7 @@ TestRoutingResult compute_test_routing(const Config& config,
 
     std::unique_ptr<Firewall> firewall;
     try {
-        firewall = create_firewall("auto");
+        firewall = create_firewall(firewall_backend_preference(config));
     } catch (const std::exception& e) {
         result.warnings.push_back(
             keen_pbr3::format("Cannot check actual outbound (firewall tool unavailable): {}", e.what()));

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -45,6 +45,26 @@ void validate_optional_integer_field(const json& root,
     }
 }
 
+void validate_optional_string_field(const json& root,
+                                    const char* parent_key,
+                                    const char* child_key,
+                                    const std::string& path,
+                                    std::vector<ConfigValidationIssue>& issues) {
+    const auto parent_it = root.find(parent_key);
+    if (parent_it == root.end() || !parent_it->is_object()) {
+        return;
+    }
+
+    const auto child_it = parent_it->find(child_key);
+    if (child_it == parent_it->end() || child_it->is_null()) {
+        return;
+    }
+
+    if (!child_it->is_string()) {
+        add_issue(issues, path, path + " must be a string");
+    }
+}
+
 void validate_optional_hex_string_field(const json& root,
                                         const char* parent_key,
                                         const char* child_key,
@@ -343,6 +363,8 @@ Config parse_config(const std::string& json_str) {
         "daemon.firewall_verify_max_bytes", issues);
     validate_optional_integer_field(
         parsed_json, "daemon", "max_file_size_bytes", "daemon.max_file_size_bytes", issues);
+    validate_optional_string_field(
+        parsed_json, "daemon", "firewall_backend", "daemon.firewall_backend", issues);
     validate_route_rule_specs(parsed_json, issues);
 
     if (!issues.empty()) {
@@ -373,6 +395,14 @@ void validate_config(const Config& cfg) {
         *cfg.daemon->max_file_size_bytes <= 0) {
         add_issue(issues, "daemon.max_file_size_bytes",
                   "daemon.max_file_size_bytes must be greater than 0");
+    }
+
+    if (cfg.daemon && cfg.daemon->firewall_backend.has_value()) {
+        const std::string backend = trim_copy(*cfg.daemon->firewall_backend);
+        if (backend != "auto" && backend != "iptables" && backend != "nftables") {
+            add_issue(issues, "daemon.firewall_backend",
+                      "daemon.firewall_backend must be one of: auto, iptables, nftables");
+        }
     }
 
     if (cfg.lists_autoupdate) {
@@ -666,6 +696,12 @@ size_t max_file_size_bytes(const Config& config) {
                            .max_file_size_bytes.value_or(
                                static_cast<int64_t>(kDefaultMaxFileSizeBytes));
     return static_cast<size_t>(bytes);
+}
+
+std::string firewall_backend_preference(const Config& config) {
+    const std::string backend = trim_copy(
+        config.daemon.value_or(DaemonConfig{}).firewall_backend.value_or("auto"));
+    return backend.empty() ? "auto" : backend;
 }
 
 Config parse_and_validate_config(const std::string& json_str) {

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -65,6 +65,7 @@ Config parse_config(const std::string& json_str);
 void validate_config(const Config& config);
 Config parse_and_validate_config(const std::string& json_str);
 size_t max_file_size_bytes(const Config& config);
+std::string firewall_backend_preference(const Config& config);
 
 // --- Fwmark allocation ---
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -143,7 +143,7 @@ Daemon::Daemon(Config config,
     , config_(std::move(config))
     , config_path_(std::move(config_path))
     , opts_(std::move(opts))
-    , firewall_(create_firewall("auto"))
+    , firewall_(create_firewall(firewall_backend_preference(config_)))
     , netlink_()
     , route_table_(netlink_)
     , policy_rules_(netlink_)

--- a/tests/test_config_validation.cpp
+++ b/tests/test_config_validation.cpp
@@ -573,3 +573,33 @@ TEST_CASE("daemon.firewall_verify_max_bytes: rejects non-integer value") {
 TEST_CASE("daemon.firewall_verify_max_bytes: rejects negative value") {
     CHECK_THROWS_AS(parse_test_config(R"({"daemon":{"firewall_verify_max_bytes":-1}})"), ConfigError);
 }
+
+TEST_CASE("daemon.firewall_backend: defaults to auto when absent") {
+    auto cfg = parse_test_config(R"({"daemon":{}})");
+    CHECK(firewall_backend_preference(cfg) == "auto");
+}
+
+TEST_CASE("daemon.firewall_backend: accepts auto") {
+    auto cfg = parse_test_config(R"({"daemon":{"firewall_backend":"auto"}})");
+    CHECK(firewall_backend_preference(cfg) == "auto");
+}
+
+TEST_CASE("daemon.firewall_backend: accepts iptables") {
+    auto cfg = parse_test_config(R"({"daemon":{"firewall_backend":"iptables"}})");
+    CHECK(firewall_backend_preference(cfg) == "iptables");
+}
+
+TEST_CASE("daemon.firewall_backend: accepts nftables") {
+    auto cfg = parse_test_config(R"({"daemon":{"firewall_backend":"nftables"}})");
+    CHECK(firewall_backend_preference(cfg) == "nftables");
+}
+
+TEST_CASE("daemon.firewall_backend: rejects non-string value") {
+    const auto issues = parse_issues(R"({"daemon":{"firewall_backend":true}})");
+    REQUIRE(issues.size() == 1);
+    CHECK(issues[0].path == "daemon.firewall_backend");
+}
+
+TEST_CASE("daemon.firewall_backend: rejects unsupported value") {
+    CHECK_THROWS_AS(parse_test_config(R"({"daemon":{"firewall_backend":"pf"}})"), ConfigError);
+}


### PR DESCRIPTION
### Motivation
- Allow selecting which firewall tool the daemon uses instead of hardcoding `auto` so deployments can force `iptables` or `nftables` when required.
- Preserve existing `auto` behavior (prefer `nft`, fallback to `iptables`) while validating explicit choices early.

### Description
- Add new config field `daemon.firewall_backend` (string) to the generated API/config types and JSON (accepted values: `auto`, `iptables`, `nftables`).
- Add parsing and validation for `daemon.firewall_backend` including type-check (`string`) and allowed-value checks, plus helper `firewall_backend_preference(const Config&)` that normalizes/defaults to `auto`.
- Wire the runtime to honor the configured backend by passing `firewall_backend_preference(config)` to `create_firewall(...)` from daemon startup, `status`, and `test-routing` code paths.
- Update `config.example.json`, docs (`docs/content/docs/configuration/advanced.md`, `docs/openapi.yaml`) and add unit tests covering defaulting, accepted values, and invalid types/values.

### Testing
- Added unit tests in `tests/test_config_validation.cpp` exercising `daemon.firewall_backend` parsing and validation.
- Attempted to build with `make`, but CMake configure failed in this environment due to a missing system dependency (`libnl-3.0`), so the full test suite was not executed here.
- Static/compilation changes are localized to config parsing, docs, and wiring of the backend preference; tests should run successfully in CI or a local environment with system dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d891915624832aad16dede054c2842)