### PR TITLE
Expose `ttlMs` as a global field and stop resetting it when switching source groups

### DIFF
--- a/frontend/src/pages/list-upsert-page.tsx
+++ b/frontend/src/pages/list-upsert-page.tsx
@@ -285,9 +285,6 @@ function ListForm({
       form.setFieldValue("ipCidrs", "")
     }
 
-    if (group !== "url") {
-      form.setFieldValue("ttlMs", sampleNewList.ttlMs)
-    }
   }
 
   return (
@@ -347,6 +344,41 @@ function ListForm({
                       />
                       <FieldHint
                         description={t("pages.listUpsert.fields.nameHint")}
+                        error={error ?? null}
+                      />
+                    </FieldContent>
+                  </Field>
+                )
+              }}
+            </form.Field>
+
+            <form.Field
+              name="ttlMs"
+              validators={{
+                onMount: ({ value }) => getTtlError(value, t) ?? undefined,
+                onChange: ({ value }) => getTtlError(value, t) ?? undefined,
+              }}
+            >
+              {(field) => {
+                const error = getFirstFieldError(field.state.meta.errors)
+
+                return (
+                  <Field invalid={Boolean(error)}>
+                    <FieldLabel htmlFor="list-ttl-ms">
+                      {t("pages.listUpsert.fields.ttlMs")}
+                    </FieldLabel>
+                    <FieldContent>
+                      <Input
+                        aria-invalid={Boolean(error)}
+                        id="list-ttl-ms"
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        value={field.state.value}
+                      />
+                      <FieldHint
+                        description={t("pages.listUpsert.fields.ttlMsHint")}
                         error={error ?? null}
                       />
                     </FieldContent>
@@ -422,40 +454,6 @@ function ListForm({
                 )}
               </form.Field>
 
-              <form.Field
-                name="ttlMs"
-                validators={{
-                  onMount: ({ value }) => getTtlError(value, t) ?? undefined,
-                  onChange: ({ value }) => getTtlError(value, t) ?? undefined,
-                }}
-              >
-                {(field) => {
-                  const error = getFirstFieldError(field.state.meta.errors)
-
-                  return (
-                    <Field invalid={Boolean(error)}>
-                      <FieldLabel htmlFor="list-ttl-ms">
-                        {t("pages.listUpsert.fields.ttlMs")}
-                      </FieldLabel>
-                      <FieldContent>
-                        <Input
-                          aria-invalid={Boolean(error)}
-                          id="list-ttl-ms"
-                          onBlur={field.handleBlur}
-                          onChange={(event) =>
-                            field.handleChange(event.target.value)
-                          }
-                          value={field.state.value}
-                        />
-                        <FieldHint
-                          description={t("pages.listUpsert.fields.ttlMsHint")}
-                          error={error ?? null}
-                        />
-                      </FieldContent>
-                    </Field>
-                  )
-                }}
-              </form.Field>
             </FieldGroup>
           </CardContent>
         </Card>


### PR DESCRIPTION
### Motivation
- Make the list TTL editable regardless of the selected source group by exposing `ttlMs` at the top-level form instead of inside the URL source group.
- Prevent unexpected loss of a user-entered TTL when switching between `LIST_SOURCE_GROUPS` by removing automatic resets of `ttlMs` on source change.

### Description
- Added a top-level `form.Field` for `ttlMs` with validators that call `getTtlError` and display hint/error UI next to the `name` field.
- Removed the duplicate `ttlMs` field from the URL source group so the TTL is no longer shown/edited only for URL lists.
- Deleted the logic that reset `ttlMs` to `sampleNewList.ttlMs` during `handleSourceGroupSelect`, so `ttlMs` is preserved when changing source groups.

### Testing
- Ran the frontend unit test suite via `yarn test`, which completed successfully.
- Ran TypeScript type checks with `tsc --noEmit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d904a86398832a9c9f196c4d39abd4)