### PR TITLE
openwrt: avoid recreating dnsmasq temp conf during package removal

### DIFF
--- a/packages/openwrt/keen-pbr/files/etc/init.d/keen-pbr
+++ b/packages/openwrt/keen-pbr/files/etc/init.d/keen-pbr
@@ -38,6 +38,8 @@ start_service() {
 }
 
 stop_service() {
+    [ -n "$KEEN_PBR_SKIP_DNSMASQ" ] && return 0
+
     if [ -x "$HELPER" ]; then
         "$HELPER" deactivate || true
     fi

--- a/packages/openwrt/keen-pbr/files/prerm
+++ b/packages/openwrt/keen-pbr/files/prerm
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-/etc/init.d/keen-pbr stop || true
 /etc/init.d/keen-pbr disable || true
+KEEN_PBR_SKIP_DNSMASQ=1 /etc/init.d/keen-pbr stop || true
 /usr/lib/keen-pbr/dnsmasq.sh uninstall-persistent || true
 
 cat <<'EOF'


### PR DESCRIPTION
### Motivation
- Prevent the package removal flow from re-creating `/tmp/dnsmasq.*.d/keen-pbr.conf`, which caused DNS to stop working during uninstall/reinstall windows.

### Description
- Add `KEEN_PBR_SKIP_DNSMASQ` guard to `stop_service()` in `packages/openwrt/keen-pbr/files/etc/init.d/keen-pbr` so callers can stop the daemon without calling the helper `deactivate` path.
- Update `packages/openwrt/keen-pbr/files/prerm` to `disable` the service, call `KEEN_PBR_SKIP_DNSMASQ=1 /etc/init.d/keen-pbr stop || true`, and then run `/usr/lib/keen-pbr/dnsmasq.sh uninstall-persistent || true` to clean up UCI and temp files in the correct order.

### Testing
- Ran `make -j2` in this environment and the build failed during CMake configure due to a missing system dependency `libnl-3.0`, so a full package build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9064598e4832a8161ffc6c45427b2)