### PR TITLE
Add InterfaceMonitor to refresh routing/firewall on interface events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ set(SOURCES
   src/cmd/test_routing.cpp
   src/routing/target.cpp
   src/routing/netlink.cpp
+  src/routing/interface_monitor.cpp
   src/routing/route_table.cpp
   src/routing/policy_rule.cpp
   src/routing/routing_verifier.cpp

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -452,7 +452,7 @@ void Daemon::handle_sigusr1() {
     auto& log = Logger::instance();
     log.info("SIGUSR1: verifying routing tables and triggering URL tests...");
 
-    refresh_runtime_for_signal_equivalent();
+    refresh_iproute_and_firewall_runtime();
 
     // Trigger immediate URL tests for all urltest outbounds
     if (urltest_manager_) {
@@ -477,7 +477,7 @@ void Daemon::handle_sighup() {
     }
 }
 
-void Daemon::refresh_runtime_for_signal_equivalent() {
+void Daemon::refresh_iproute_and_firewall_runtime() {
     auto& log = Logger::instance();
     try {
         route_table_.clear();
@@ -509,7 +509,7 @@ void Daemon::handle_interface_state_change(const std::string& interface_name, bo
     log.info("Interface {} state changed to {}, iproute and firewall refresh triggered",
              interface_name,
              is_up ? "UP" : "DOWN");
-    refresh_runtime_for_signal_equivalent();
+    refresh_iproute_and_firewall_runtime();
 }
 
 void Daemon::handle_interface_monitor_events(uint32_t events) {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -144,6 +144,10 @@ Daemon::Daemon(Config config,
     , config_path_(std::move(config_path))
     , opts_(std::move(opts))
     , firewall_(create_firewall(firewall_backend_preference(config_)))
+    , interface_monitor_(std::make_unique<InterfaceMonitor>(
+          [this](const std::string& interface_name, bool is_up) {
+              handle_interface_state_change(interface_name, is_up);
+          }))
     , netlink_()
     , route_table_(netlink_)
     , policy_rules_(netlink_)
@@ -448,16 +452,7 @@ void Daemon::handle_sigusr1() {
     auto& log = Logger::instance();
     log.info("SIGUSR1: verifying routing tables and triggering URL tests...");
 
-    // Re-add static routing tables/ip rules in case they were lost
-    try {
-        route_table_.clear();
-        policy_rules_.clear();
-        setup_static_routing();
-        publish_runtime_state();
-        log.info("SIGUSR1: static routing tables verified.");
-    } catch (const std::exception& e) {
-        log.error("SIGUSR1: error verifying routing: {}", e.what());
-    }
+    refresh_runtime_for_signal_equivalent();
 
     // Trigger immediate URL tests for all urltest outbounds
     if (urltest_manager_) {
@@ -479,6 +474,57 @@ void Daemon::handle_sighup() {
         log.info("SIGHUP: full reload complete.");
     } catch (const std::exception& e) {
         log.error("SIGHUP: reload failed: {}", e.what());
+    }
+}
+
+void Daemon::refresh_runtime_for_signal_equivalent() {
+    auto& log = Logger::instance();
+    try {
+        route_table_.clear();
+        policy_rules_.clear();
+        setup_static_routing();
+        apply_firewall();
+        publish_runtime_state();
+        log.info("Runtime iproute and firewall refresh complete.");
+    } catch (const std::exception& e) {
+        log.error("Runtime iproute and firewall refresh failed: {}", e.what());
+    }
+}
+
+bool Daemon::is_interface_outbound_in_use(const std::string& interface_name) const {
+    const auto outbounds = config_.outbounds.value_or(std::vector<Outbound>{});
+    return std::any_of(outbounds.begin(), outbounds.end(), [&interface_name](const Outbound& outbound) {
+        return outbound.type == OutboundType::INTERFACE &&
+               outbound.interface.has_value() &&
+               outbound.interface.value() == interface_name;
+    });
+}
+
+void Daemon::handle_interface_state_change(const std::string& interface_name, bool is_up) {
+    auto& log = Logger::instance();
+    if (!is_interface_outbound_in_use(interface_name)) {
+        return;
+    }
+
+    log.info("Interface {} state changed to {}, iproute and firewall refresh triggered",
+             interface_name,
+             is_up ? "UP" : "DOWN");
+    refresh_runtime_for_signal_equivalent();
+}
+
+void Daemon::handle_interface_monitor_events(uint32_t events) {
+    if ((events & EPOLLIN) == 0) {
+        return;
+    }
+
+    if (!interface_monitor_) {
+        return;
+    }
+
+    try {
+        interface_monitor_->handle_events();
+    } catch (const std::exception& e) {
+        Logger::instance().error("Interface monitor event handling failed: {}", e.what());
     }
 }
 
@@ -640,6 +686,14 @@ void Daemon::run() {
     publish_runtime_state();
 
     setup_dns_probe();
+
+    if (interface_monitor_) {
+        add_fd(interface_monitor_->fd(),
+               EPOLLIN,
+               [this](uint32_t events) { handle_interface_monitor_events(events); },
+               true,
+               "interface-monitor");
+    }
 
 #ifdef WITH_API
     setup_api();

--- a/src/daemon/daemon.hpp
+++ b/src/daemon/daemon.hpp
@@ -146,7 +146,7 @@ private:
     void handle_interface_monitor_events(uint32_t events);
     void handle_interface_state_change(const std::string& interface_name, bool is_up);
     bool is_interface_outbound_in_use(const std::string& interface_name) const;
-    void refresh_runtime_for_signal_equivalent();
+    void refresh_iproute_and_firewall_runtime();
 
     // Business logic methods
     void setup_static_routing();

--- a/src/daemon/daemon.hpp
+++ b/src/daemon/daemon.hpp
@@ -19,6 +19,7 @@
 #include "config_store.hpp"
 #include "../health/routing_health_checker.hpp"
 #include "../health/url_tester.hpp"
+#include "../routing/interface_monitor.hpp"
 #include "../routing/firewall_state.hpp"
 #include "../routing/netlink.hpp"
 #include "../routing/policy_rule.hpp"
@@ -142,6 +143,10 @@ private:
     // Signal handlers
     void handle_sigusr1();
     void handle_sighup();
+    void handle_interface_monitor_events(uint32_t events);
+    void handle_interface_state_change(const std::string& interface_name, bool is_up);
+    bool is_interface_outbound_in_use(const std::string& interface_name) const;
+    void refresh_runtime_for_signal_equivalent();
 
     // Business logic methods
     void setup_static_routing();
@@ -243,6 +248,7 @@ private:
 
     // Subsystems
     std::unique_ptr<Firewall> firewall_;
+    std::unique_ptr<InterfaceMonitor> interface_monitor_;
     NetlinkManager netlink_;
     RouteTable route_table_;
     PolicyRuleManager policy_rules_;

--- a/src/routing/interface_monitor.cpp
+++ b/src/routing/interface_monitor.cpp
@@ -4,8 +4,9 @@
 
 #include <cerrno>
 #include <cstring>
-#include <linux/if.h>
+#include <net/if.h>
 #include <linux/rtnetlink.h>
+#include <sys/socket.h>
 #include <unordered_map>
 
 #include <netlink/attr.h>

--- a/src/routing/interface_monitor.cpp
+++ b/src/routing/interface_monitor.cpp
@@ -1,0 +1,155 @@
+#include "interface_monitor.hpp"
+
+#include "../util/format_compat.hpp"
+
+#include <cerrno>
+#include <cstring>
+#include <linux/if.h>
+#include <linux/rtnetlink.h>
+#include <unordered_map>
+
+#include <netlink/attr.h>
+#include <netlink/errno.h>
+#include <netlink/msg.h>
+#include <netlink/netlink.h>
+#include <netlink/socket.h>
+
+namespace keen_pbr3 {
+
+namespace {
+
+constexpr int kLinkAttributeMax = IFLA_MAX + 1;
+
+} // namespace
+
+struct InterfaceMonitor::Impl {
+    explicit Impl(InterfaceStateCallback callback)
+        : callback(std::move(callback)) {}
+
+    ~Impl() {
+        if (socket) {
+            nl_close(socket);
+            nl_socket_free(socket);
+            socket = nullptr;
+        }
+    }
+
+    static int on_nl_message(struct nl_msg* msg, void* arg) {
+        auto* impl = static_cast<Impl*>(arg);
+        if (!impl) {
+            return NL_OK;
+        }
+
+        impl->handle_link_message(msg);
+        return NL_OK;
+    }
+
+    void handle_link_message(struct nl_msg* msg) {
+        if (!msg || !callback) {
+            return;
+        }
+
+        struct nlmsghdr* hdr = nlmsg_hdr(msg);
+        if (!hdr) {
+            return;
+        }
+
+        if (hdr->nlmsg_type != RTM_NEWLINK && hdr->nlmsg_type != RTM_DELLINK) {
+            return;
+        }
+
+        auto* if_info = static_cast<ifinfomsg*>(nlmsg_data(hdr));
+        if (!if_info) {
+            return;
+        }
+
+        struct nlattr* attrs[kLinkAttributeMax] = {};
+        const int parse_err = nlmsg_parse(hdr,
+                                          sizeof(*if_info),
+                                          attrs,
+                                          IFLA_MAX,
+                                          nullptr);
+        if (parse_err < 0 || attrs[IFLA_IFNAME] == nullptr) {
+            return;
+        }
+
+        const char* if_name_raw = static_cast<const char*>(nla_data(attrs[IFLA_IFNAME]));
+        if (!if_name_raw || *if_name_raw == '\0') {
+            return;
+        }
+
+        const std::string interface_name(if_name_raw);
+        const bool is_up = (hdr->nlmsg_type == RTM_NEWLINK) && ((if_info->ifi_flags & IFF_UP) != 0);
+
+        const auto previous = interface_state.find(interface_name);
+        if (previous != interface_state.end() && previous->second == is_up) {
+            return;
+        }
+
+        interface_state[interface_name] = is_up;
+        callback(interface_name, is_up);
+    }
+
+    InterfaceStateCallback callback;
+    struct nl_sock* socket{nullptr};
+    std::unordered_map<std::string, bool> interface_state;
+};
+
+InterfaceMonitor::InterfaceMonitor(InterfaceStateCallback callback)
+    : impl_(std::make_unique<Impl>(std::move(callback))) {
+    impl_->socket = nl_socket_alloc();
+    if (!impl_->socket) {
+        throw InterfaceMonitorError("Failed to allocate netlink socket for interface monitor");
+    }
+
+    int err = nl_connect(impl_->socket, NETLINK_ROUTE);
+    if (err < 0) {
+        throw InterfaceMonitorError(
+            format("Failed to connect interface monitor netlink socket: {}", nl_geterror(err)));
+    }
+
+    err = nl_socket_add_memberships(impl_->socket, RTNLGRP_LINK, 0);
+    if (err < 0) {
+        throw InterfaceMonitorError(
+            format("Failed to subscribe interface monitor to link group: {}", nl_geterror(err)));
+    }
+
+    nl_socket_set_nonblocking(impl_->socket);
+    nl_socket_disable_seq_check(impl_->socket);
+    nl_socket_modify_cb(impl_->socket,
+                        NL_CB_VALID,
+                        NL_CB_CUSTOM,
+                        &InterfaceMonitor::Impl::on_nl_message,
+                        impl_.get());
+}
+
+InterfaceMonitor::~InterfaceMonitor() = default;
+
+int InterfaceMonitor::fd() const {
+    if (!impl_ || !impl_->socket) {
+        throw InterfaceMonitorError("Interface monitor socket is not initialized");
+    }
+    return nl_socket_get_fd(impl_->socket);
+}
+
+void InterfaceMonitor::handle_events() {
+    if (!impl_ || !impl_->socket) {
+        return;
+    }
+
+    while (true) {
+        int err = nl_recvmsgs_default(impl_->socket);
+        if (err == 0) {
+            continue;
+        }
+
+        if (err == -NLE_AGAIN || errno == EAGAIN || errno == EWOULDBLOCK) {
+            break;
+        }
+
+        throw InterfaceMonitorError(
+            format("Failed to receive interface monitor netlink messages: {}", nl_geterror(err)));
+    }
+}
+
+} // namespace keen_pbr3

--- a/src/routing/interface_monitor.hpp
+++ b/src/routing/interface_monitor.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace keen_pbr3 {
+
+class InterfaceMonitorError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class InterfaceMonitor {
+public:
+    using InterfaceStateCallback = std::function<void(const std::string& interface_name, bool is_up)>;
+
+    explicit InterfaceMonitor(InterfaceStateCallback callback);
+    ~InterfaceMonitor();
+
+    InterfaceMonitor(const InterfaceMonitor&) = delete;
+    InterfaceMonitor& operator=(const InterfaceMonitor&) = delete;
+    InterfaceMonitor(InterfaceMonitor&&) = delete;
+    InterfaceMonitor& operator=(InterfaceMonitor&&) = delete;
+
+    int fd() const;
+    void handle_events();
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace keen_pbr3


### PR DESCRIPTION
### Motivation
- Detect kernel network interface state changes and trigger the same runtime refresh that SIGUSR1 performs so routing tables and firewall rules stay consistent when outbounds bound to an interface go up/down.
- Consolidate the SIGUSR1 refresh logic into a reusable routine that also includes applying firewall state.

### Description
- Add a new `InterfaceMonitor` (netlink + libnl) implementation in `src/routing/interface_monitor.hpp/cpp` that watches RTM_*LINK events and invokes a callback when an interface's up/down state changes.
- Wire `InterfaceMonitor` into the `Daemon` by adding a `std::unique_ptr<InterfaceMonitor>` member, constructing it with a callback to `handle_interface_state_change`, and registering its file descriptor with epoll in `Daemon::run`.
- Introduce `refresh_runtime_for_signal_equivalent()`, `is_interface_outbound_in_use()`, `handle_interface_state_change()`, and `handle_interface_monitor_events()` in `Daemon` and replace the inlined SIGUSR1 routing refresh with a call to the new refresh function.
- Update `CMakeLists.txt` to include the new source file and add the include in `daemon.hpp`.
- The `InterfaceMonitor` implementation uses libnl to subscribe to `RTNLGRP_LINK`, parse link messages, deduplicate state notifications, and call back into the daemon only for relevant changes.

### Testing
- Performed a local configure and build with `cmake`/`make`, and the project compiled successfully.
- No automated unit tests were added or modified in this change, and no test suite (`ctest`) was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3a46724c832a90d63576656fa7e6)