### PR TITLE
Fix nftables port matches when protocol is unspecified

### DIFF
--- a/src/firewall/nftables.cpp
+++ b/src/firewall/nftables.cpp
@@ -239,15 +239,19 @@ nlohmann::json NftablesFirewall::build_port_match_exprs(const std::string& proto
     if (!proto.empty()) {
         exprs.push_back({{"match", {{"op", "=="}, {"left", {{"meta", {{"key", "l4proto"}}}}}, {"right", proto}}}});
     }
+    // For port payload fields, nft expects a transport-header payload protocol.
+    // When proto is unspecified, use "th" (transport header) so expressions like
+    // dport/sport are still valid.
+    const std::string payload_proto = proto.empty() ? "th" : proto;
     // src_port match
     if (!src_port.empty()) {
         std::string op = negate_src_port ? "!=" : "==";
-        exprs.push_back({{"match", {{"op", op}, {"left", {{"payload", {{"protocol", proto}, {"field", "sport"}}}}}, {"right", port_spec_to_nft_rhs(src_port)}}}});
+        exprs.push_back({{"match", {{"op", op}, {"left", {{"payload", {{"protocol", payload_proto}, {"field", "sport"}}}}}, {"right", port_spec_to_nft_rhs(src_port)}}}});
     }
     // dst_port match
     if (!dst_port.empty()) {
         std::string op = negate_dst_port ? "!=" : "==";
-        exprs.push_back({{"match", {{"op", op}, {"left", {{"payload", {{"protocol", proto}, {"field", "dport"}}}}}, {"right", port_spec_to_nft_rhs(dst_port)}}}});
+        exprs.push_back({{"match", {{"op", op}, {"left", {{"payload", {{"protocol", payload_proto}, {"field", "dport"}}}}}, {"right", port_spec_to_nft_rhs(dst_port)}}}});
     }
     return exprs;
 }


### PR DESCRIPTION
### Motivation
- Prevent runtime failure where nft JSON emitted `"protocol": ""` for port matches without an explicit `proto`, which caused `nft` to error with `Unknown payload protocol ''`.

### Description
- Change `NftablesFirewall::build_port_match_exprs` to use `payload_proto = proto.empty() ? "th" : proto` and use `payload_proto` for `sport`/`dport` `payload.protocol` fields while keeping explicit `proto` behavior (and the existing `meta l4proto` match) unchanged; this avoids invalid empty `protocol` values in generated nft JSON (file: `src/firewall/nftables.cpp`).

### Testing
- Ran `make` from the repository root as required by the project instructions, but CMake configure failed in this environment because `libnl-3.0` is missing, so a full compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da6819bf98832aa1f939131405db07)