### PR TITLE
Skip applying resolver TXT hash if timestamp predates an ongoing apply

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1431,6 +1431,22 @@ void Daemon::refresh_resolver_config_hash_actual_async() {
                     }
 
                     if (has_parsed_value) {
+                        const std::int64_t apply_started_ts =
+                            apply_started_ts_.load(std::memory_order_acquire);
+                        if (apply_started_ts > 0 &&
+                            parsed_value.ts.has_value() &&
+                            *parsed_value.ts < apply_started_ts) {
+                            Logger::instance().trace(
+                                "resolver_hash_refresh_skip",
+                                "resolver={} reason=txt_older_than_apply txt_ts={} apply_started_ts={}",
+                                resolver_addr,
+                                *parsed_value.ts,
+                                apply_started_ts);
+                            has_parsed_value = false;
+                        }
+                    }
+
+                    if (has_parsed_value) {
                         resolver_config_hash_actual_ = parsed_value.hash;
                         resolver_config_hash_actual_ts_ = parsed_value.ts;
                         Logger::instance().info("Resolver config hash (actual): {}",


### PR DESCRIPTION
### Motivation
- Prevent applying an older resolver TXT-derived config hash when a runtime apply is already in progress, avoiding regressions to stale configuration.

### Description
- In `Daemon::refresh_resolver_config_hash_actual_async` add a check that compares `parsed_value.ts` against `apply_started_ts_` and treat the TXT result as absent when the TXT timestamp is older than the apply start.
- Log a trace with key `resolver_hash_refresh_skip` and reason `txt_older_than_apply` including `txt_ts` and `apply_started_ts` when skipping the parsed value.
- Preserve existing behavior of updating `resolver_config_hash_actual_` and `resolver_config_hash_actual_ts_` only when a valid parsed value remains.

### Testing
- Built the project (`make`) and ran the automated unit test suite (`make test`) and the build succeeded and all tests passed.
- Ran the resolver-related tests in the suite and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc9cc14e0832abf41a36f2c57e126)