### PR TITLE
Short-circuit mark rules in nftables/iptables (first-match-wins)

### DIFF
--- a/src/firewall/iptables.cpp
+++ b/src/firewall/iptables.cpp
@@ -233,6 +233,12 @@ std::vector<std::string> IptablesFirewall::build_rule_lines(
                     addr_frag,
                     pp,
                     pr.fwmark));
+                lines.push_back(keen_pbr3::format(
+                    "-A {}{}{}{} -j RETURN\n",
+                    CHAIN_NAME,
+                    iface_frag,
+                    addr_frag,
+                    pp));
             } else if (pr.action == PendingRule::Drop) {
                 lines.push_back(keen_pbr3::format(
                     "-A {}{}{}{} -j DROP\n",
@@ -258,6 +264,13 @@ std::vector<std::string> IptablesFirewall::build_rule_lines(
                     addr_frag,
                     pp,
                     pr.fwmark));
+                lines.push_back(keen_pbr3::format(
+                    "-A {} -m set --match-set {} dst{}{}{} -j RETURN\n",
+                    CHAIN_NAME,
+                    pr.set_name,
+                    iface_frag,
+                    addr_frag,
+                    pp));
             } else if (pr.action == PendingRule::Drop) {
                 lines.push_back(keen_pbr3::format(
                     "-A {} -m set --match-set {} dst{}{}{} -j DROP\n",

--- a/src/firewall/nftables.cpp
+++ b/src/firewall/nftables.cpp
@@ -363,6 +363,7 @@ nlohmann::json NftablesFirewall::build_mark_rule_json(const PendingRule& pr) {
     }
     expr.push_back({{"counter", nullptr}});
     expr.push_back({{"mangle", {{"key", {{"meta", {{"key", "mark"}}}}}, {"value", pr.fwmark}}}});
+    expr.push_back({{"accept", nullptr}});
     return {{"add", {{"rule", {
         {"family", "inet"},
         {"table", TABLE_NAME},

--- a/tests/test_iptables_builder.cpp
+++ b/tests/test_iptables_builder.cpp
@@ -215,6 +215,8 @@ TEST_CASE("build_ipt_script: IPv4 mark rule") {
   CHECK(s.find("-A PREROUTING -j KeenPbrTable") != std::string::npos);
   CHECK(s.find("-A KeenPbrTable -m set --match-set myset dst -j MARK "
                "--set-mark 0x100") != std::string::npos);
+  CHECK(s.find("-A KeenPbrTable -m set --match-set myset dst -j RETURN") !=
+        std::string::npos);
   CHECK(s.size() >= 7);
   CHECK(s.substr(s.size() - 7) == "COMMIT\n");
 }
@@ -235,6 +237,8 @@ TEST_CASE("build_ipt_script: IPv6 mark rule") {
   auto s = T::build_ipt_script(true, {mark_rule("v6set", true, 0x200)});
   CHECK(s.find("-A KeenPbrTable -m set --match-set v6set dst -j MARK "
                "--set-mark 0x200") != std::string::npos);
+  CHECK(s.find("-A KeenPbrTable -m set --match-set v6set dst -j RETURN") !=
+        std::string::npos);
   CHECK(s.substr(s.size() - 7) == "COMMIT\n");
 }
 

--- a/tests/test_nftables_builder.cpp
+++ b/tests/test_nftables_builder.cpp
@@ -261,6 +261,7 @@ TEST_CASE("build_rule_add_commands: prefilter rules lead the prerouting chain") 
   CHECK(mark_expr[0]["match"]["left"]["payload"]["protocol"] == "ip");
   CHECK(mark_expr[0]["match"]["right"] == "@myset");
   CHECK(mark_expr[2]["mangle"]["value"] == 256);
+  CHECK(mark_expr[3].contains("accept"));
 }
 
 TEST_CASE("build_rule_add_commands: config-derived prefilter omits interface guard when inbound list is empty") {
@@ -330,6 +331,7 @@ TEST_CASE("build_mark_rule_json: IPv4 mark rule") {
   CHECK(expr[1].contains("counter"));
   CHECK(expr[2]["mangle"]["key"]["meta"]["key"] == "mark");
   CHECK(expr[2]["mangle"]["value"] == 256);
+  CHECK(expr[3].contains("accept"));
 }
 
 TEST_CASE("build_mark_rule_json: IPv6 mark rule") {
@@ -341,6 +343,7 @@ TEST_CASE("build_mark_rule_json: IPv6 mark rule") {
 TEST_CASE("build_mark_rule_json: zero fwmark is valid") {
   auto j = T::build_mark_rule_json("zeroset", AF_INET, 0);
   CHECK(j["add"]["rule"]["expr"][2]["mangle"]["value"] == 0);
+  CHECK(j["add"]["rule"]["expr"][3].contains("accept"));
 }
 
 // =============================================================================
@@ -583,8 +586,8 @@ TEST_CASE(
 TEST_CASE("build_mark_rule_json: no filter → no port exprs (regression)") {
   auto j = T::build_mark_rule_json("myset", AF_INET, 0x100);
   const auto &expr = j["add"]["rule"]["expr"];
-  // Should be exactly 3: daddr match, counter, mangle
-  CHECK(expr.size() == 3);
+  // Should be exactly 4: daddr match, counter, mangle, accept
+  CHECK(expr.size() == 4);
 }
 
 TEST_CASE("build_drop_rule_json: no filter → no port exprs (regression)") {
@@ -650,8 +653,8 @@ TEST_CASE("build_mark_rule_json: src_addr → saddr expr present") {
   f.src_addr = {"192.168.10.0/24"};
   auto j = T::build_mark_rule_json("myset", AF_INET, 0x100, f);
   const auto &expr = j["add"]["rule"]["expr"];
-  // daddr @set, saddr match, counter, mangle = 4
-  CHECK(expr.size() == 4);
+  // daddr @set, saddr match, counter, mangle, accept = 5
+  CHECK(expr.size() == 5);
   bool has_saddr = false;
   for (const auto &e : expr) {
     if (e.contains("match") && e["match"]["left"].contains("payload") &&
@@ -680,10 +683,10 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "build_mark_rule_json: no filter → still exactly 3 exprs (regression)") {
+    "build_mark_rule_json: no filter → still exactly 4 exprs (regression)") {
   auto j = T::build_mark_rule_json("myset", AF_INET, 0x100);
   const auto &expr = j["add"]["rule"]["expr"];
-  CHECK(expr.size() == 3);
+  CHECK(expr.size() == 4);
 }
 
 // =============================================================================


### PR DESCRIPTION
### Motivation
- Ensure firewall mark-based routing uses first-match-wins semantics so a matching mark rule cannot be overridden by later rules for the same packet.

### Description
- For nftables, append an `accept` verdict after the `mangle` (`meta mark set`) action in `NftablesFirewall::build_mark_rule_json` so the chain stops processing once a mark is set (`src/firewall/nftables.cpp`).
- For iptables, emit an immediate `RETURN` rule right after each `MARK --set-mark` rule in both direct and set-based code paths inside `IptablesFirewall::build_rule_lines`, so the custom chain exits after the first matching mark rule (`src/firewall/iptables.cpp`).
- Update builder unit tests to assert the new short-circuit behavior and adjust expectations for expression/line counts in `tests/test_nftables_builder.cpp` and `tests/test_iptables_builder.cpp`.

### Testing
- Attempted to build with `make` from the repo root, but CMake configuration failed in this environment due to a missing system dependency (`libnl-3.0`), so full build/test execution could not be completed.
- Unit test sources were updated to reflect the new behavior (`tests/test_nftables_builder.cpp`, `tests/test_iptables_builder.cpp`) but the test suite was not executed here because of the configure-time failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dccfe2d944832a8d373fff048afe40)