### PR TITLE
Relax routing rule list requirement; require at least one condition (list/addr/port)

### DIFF
--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -436,7 +436,8 @@ export const enTranslation = {
             back: "Back to routing rules",
           },
           validation: {
-            selectList: "Select at least one list.",
+            atLeastOneCondition:
+              "Specify at least one condition: list, source/destination address, or source/destination port.",
             outboundRequired: "Outbound tag is required.",
           },
           actions: { create: "Create rule", save: "Save rule" },

--- a/frontend/src/i18n/ru.ts
+++ b/frontend/src/i18n/ru.ts
@@ -447,7 +447,8 @@ export const ruTranslation = {
             back: "Назад к правилам маршрутизации",
           },
           validation: {
-            selectList: "Выберите хотя бы один список.",
+            atLeastOneCondition:
+              "Укажите хотя бы одно условие: список, адрес источника/назначения или порт источника/назначения.",
             outboundRequired: "Тег outbound обязателен.",
           },
           actions: { create: "Создать правило", save: "Сохранить правило" },

--- a/frontend/src/pages/routing-rule-upsert-page.tsx
+++ b/frontend/src/pages/routing-rule-upsert-page.tsx
@@ -113,6 +113,21 @@ export function RoutingRuleUpsertPage({
       }
 
       const nextRule = normalizeRouteRuleDraft(value)
+      const hasRuleCondition =
+        nextRule.list.length > 0 ||
+        Boolean(nextRule.src_port) ||
+        Boolean(nextRule.dest_port) ||
+        Boolean(nextRule.src_addr) ||
+        Boolean(nextRule.dest_addr)
+
+      if (!hasRuleCondition) {
+        setSaveSuccessMessage(null)
+        setMutationErrorMessage(
+          t("pages.routingRuleUpsert.validation.atLeastOneCondition")
+        )
+        return
+      }
+
       const nextRules =
         mode === "edit"
           ? rules.map((rule: RouteRule, index: number) =>
@@ -201,15 +216,7 @@ export function RoutingRuleUpsertPage({
         }}
       >
         <FieldGroup>
-          <form.Field
-            name="list"
-            validators={{
-              onChange: ({ value }) =>
-                value.length > 0
-                  ? undefined
-                  : t("pages.routingRuleUpsert.validation.selectList"),
-            }}
-          >
+          <form.Field name="list">
             {(field) => {
               const error = getFirstFieldError(field.state.meta.errors)
 

--- a/src/api/generated/api_types.hpp
+++ b/src/api/generated/api_types.hpp
@@ -917,7 +917,7 @@ namespace api {
     inline void from_json(const json & j, RouteRuleElement& x) {
         x.dest_addr = get_stack_optional<std::string>(j, "dest_addr");
         x.dest_port = get_stack_optional<std::string>(j, "dest_port");
-        x.list = j.at("list").get<std::vector<std::string>>();
+        x.list = get_stack_optional<std::vector<std::string>>(j, "list").value_or(std::vector<std::string>{});
         x.outbound = j.at("outbound").get<std::string>();
         x.proto = get_stack_optional<std::string>(j, "proto");
         x.src_addr = get_stack_optional<std::string>(j, "src_addr");

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -270,6 +270,26 @@ std::optional<std::string> get_optional_string_field(const json& object, const c
     return it->get<std::string>();
 }
 
+bool rule_has_list_condition(const json& rule) {
+    const auto list_it = rule.find("list");
+    if (list_it == rule.end() || !list_it->is_array()) {
+        return false;
+    }
+
+    for (const auto& value : *list_it) {
+        if (value.is_string() && !trim_copy(value.get<std::string>()).empty()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool rule_has_string_condition(const json& rule, const char* key) {
+    const auto value = get_optional_string_field(rule, key);
+    return value.has_value() && !trim_copy(*value).empty();
+}
+
 void validate_route_rule_specs(const json& root, std::vector<ConfigValidationIssue>& issues) {
     const auto route_it = root.find("route");
     if (route_it == root.end() || !route_it->is_object()) {
@@ -288,6 +308,18 @@ void validate_route_rule_specs(const json& root, std::vector<ConfigValidationIss
         }
 
         const std::string rule_path = "route.rules[" + std::to_string(index) + "]";
+        const bool has_any_condition =
+            rule_has_list_condition(rule) ||
+            rule_has_string_condition(rule, "src_port") ||
+            rule_has_string_condition(rule, "dest_port") ||
+            rule_has_string_condition(rule, "src_addr") ||
+            rule_has_string_condition(rule, "dest_addr");
+
+        if (!has_any_condition) {
+            add_issue(issues,
+                      rule_path,
+                      "Route rule must include at least one condition: list, src_port, dest_port, src_addr, or dest_addr.");
+        }
 
         if (auto error = validate_port_spec(get_optional_string_field(rule, "src_port"))) {
             add_issue(issues, rule_path + ".src_port", *error);

--- a/tests/test_config_validation.cpp
+++ b/tests/test_config_validation.cpp
@@ -440,6 +440,26 @@ TEST_CASE("route rule: valid port and address filters are accepted") {
     CHECK_NOTHROW(parse_config(json));
 }
 
+TEST_CASE("route rule: at least one condition is required") {
+    std::string json = R"({
+        "route":{"rules":[
+            {"list":[],"outbound":"vpn"}
+        ]}
+    })";
+    const auto issues = parse_issues(json);
+    REQUIRE_FALSE(issues.empty());
+    CHECK(issues.front().path == "route.rules[0]");
+}
+
+TEST_CASE("route rule: list is optional when another condition is present") {
+    std::string json = R"({
+        "route":{"rules":[
+            {"outbound":"vpn","src_addr":"10.0.0.1"}
+        ]}
+    })";
+    CHECK_NOTHROW(parse_config(json));
+}
+
 TEST_CASE("route rule: invalid src_port reports route.rules[0].src_port") {
     std::string json = R"({"route":{"rules":[{"list":["ads"],"outbound":"vpn","src_port":"1,,2"}]}})";
     const auto issues = parse_issues(json);

--- a/tests/test_config_validation.cpp
+++ b/tests/test_config_validation.cpp
@@ -454,7 +454,7 @@ TEST_CASE("route rule: at least one condition is required") {
 TEST_CASE("route rule: list is optional when another condition is present") {
     std::string json = R"({
         "route":{"rules":[
-            {"list":[],"outbound":"vpn","src_addr":"10.0.0.1"}
+            {"outbound":"vpn","src_addr":"10.0.0.1"}
         ]}
     })";
     CHECK_NOTHROW(parse_config(json));

--- a/tests/test_config_validation.cpp
+++ b/tests/test_config_validation.cpp
@@ -454,7 +454,7 @@ TEST_CASE("route rule: at least one condition is required") {
 TEST_CASE("route rule: list is optional when another condition is present") {
     std::string json = R"({
         "route":{"rules":[
-            {"outbound":"vpn","src_addr":"10.0.0.1"}
+            {"list":[],"outbound":"vpn","src_addr":"10.0.0.1"}
         ]}
     })";
     CHECK_NOTHROW(parse_config(json));


### PR DESCRIPTION
### Motivation
- Users should be able to create routing rules that don't select a list as long as the rule specifies at least one other matching condition (source/destination address or source/destination port).

### Description
- Add submit-time validation in `RoutingRuleUpsertPage` to require at least one of `list`, `src_port`, `dest_port`, `src_addr`, or `dest_addr` before saving, and show a localized error when none are set (`pages.routingRuleUpsert.validation.atLeastOneCondition`).
- Remove the field-level validator that previously forced a list selection so rules can omit lists when other conditions exist. (changed `frontend/src/pages/routing-rule-upsert-page.tsx`).
- Add/update i18n validation strings for the new requirement in English and Russian. (changed `frontend/src/i18n/en.ts` and `frontend/src/i18n/ru.ts`).

### Testing
- Ran the project build with `make`, which failed during CMake configuration due to a missing system dependency (`libnl-3.0`), so full build verification could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd15423e0832a92a42bec3020286a)