### PR TITLE
Fix iptables DNAT prefilter for legacy iptables-restore

### DIFF
--- a/src/firewall/iptables.cpp
+++ b/src/firewall/iptables.cpp
@@ -179,7 +179,7 @@ std::string IptablesFirewall::build_prefilter_lines(
     std::string lines;
     if (prefilter.skip_established_or_dnat) {
         lines += keen_pbr3::format(
-            "-A {} -m conntrack --ctstatus DNAT -j RETURN\n",
+            "-A {} -m conntrack --ctstate DNAT -j RETURN\n",
             CHAIN_NAME);
     }
 

--- a/tests/test_iptables_builder.cpp
+++ b/tests/test_iptables_builder.cpp
@@ -287,7 +287,7 @@ TEST_CASE("build_ipt_script: global prefilter RETURN lines are emitted before ro
       prefilter_with_interfaces({"br0"}));
 
   const std::string dnat =
-      "-A KeenPbrTable -m conntrack --ctstatus DNAT -j RETURN\n";
+      "-A KeenPbrTable -m conntrack --ctstate DNAT -j RETURN\n";
   const std::string iface =
       "-A KeenPbrTable ! -i br0 -j RETURN\n";
   const std::string mark =


### PR DESCRIPTION
### Motivation
- Older `iptables-restore` implementations reject the `--ctstatus DNAT` matcher, causing generated iptables scripts to fail with `Bad ctstatus "DNAT"` during restore.

### Description
- Replace `--ctstatus DNAT` with `--ctstate DNAT` in the iptables prefilter generation in `src/firewall/iptables.cpp` to produce a compatible matcher.
- Update the unit test expectation in `tests/test_iptables_builder.cpp` to assert the new `--ctstate DNAT` line.

### Testing
- Ran the project build via `make`, but configuration failed in this environment due to a missing system package (`libnl-3.0`), so the full build and test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd402bb9dc832a85af9138adefb5fd)