### PR TITLE
perf: skip dnsmasq restart when resolver config is unchanged

### DIFF
--- a/packages/debian/files/usr/lib/keen-pbr/dnsmasq.sh
+++ b/packages/debian/files/usr/lib/keen-pbr/dnsmasq.sh
@@ -103,7 +103,35 @@ deactivate_dnsmasq() {
     restart_dnsmasq
 }
 
+resolver_config_hash_file() {
+    echo "${STATE_DIR}/resolver-config.hash"
+}
+
+effective_config_content() {
+    if is_active; then
+        active_conf_line
+    else
+        fallback_conf_line
+    fi
+}
+
+dnsmasq_is_running() {
+    pidof dnsmasq >/dev/null 2>&1
+}
+
 restart_dnsmasq() {
+    hash_file="$(resolver_config_hash_file)"
+    new_hash="$(effective_config_content | md5sum | awk '{print $1}')"
+    old_hash=""
+    if [ -f "$hash_file" ]; then
+        old_hash="$(cat "$hash_file")"
+    fi
+    if [ "$new_hash" = "$old_hash" ] && dnsmasq_is_running; then
+        log_info "resolver config unchanged, skipping dnsmasq restart"
+        return 0
+    fi
+    mkdir -p "$STATE_DIR"
+    printf '%s\n' "$new_hash" > "$hash_file"
     if command -v systemctl >/dev/null 2>&1; then
         systemctl restart dnsmasq >/dev/null 2>&1 || true
     elif command -v service >/dev/null 2>&1; then

--- a/packages/keenetic/keen-pbr/files/opt/usr/lib/keen-pbr/dnsmasq.sh
+++ b/packages/keenetic/keen-pbr/files/opt/usr/lib/keen-pbr/dnsmasq.sh
@@ -77,8 +77,36 @@ deactivate_dnsmasq() {
     restart_dnsmasq
 }
 
+resolver_config_hash_file() {
+    echo "${STATE_DIR}/resolver-config.hash"
+}
+
+effective_config_content() {
+    if is_active; then
+        active_conf_line
+    else
+        fallback_conf_line
+    fi
+}
+
+dnsmasq_is_running() {
+    pidof dnsmasq >/dev/null 2>&1
+}
+
 restart_dnsmasq() {
     if [ -x /opt/etc/init.d/S56dnsmasq ]; then
+        hash_file="$(resolver_config_hash_file)"
+        new_hash="$(effective_config_content | md5sum | awk '{print $1}')"
+        old_hash=""
+        if [ -f "$hash_file" ]; then
+            old_hash="$(cat "$hash_file")"
+        fi
+        if [ "$new_hash" = "$old_hash" ] && dnsmasq_is_running; then
+            log_info "resolver config unchanged, skipping dnsmasq restart"
+            return 0
+        fi
+        mkdir -p "$STATE_DIR"
+        printf '%s\n' "$new_hash" > "$hash_file"
         /opt/etc/init.d/S56dnsmasq restart 2>/dev/null || true
         return 0
     fi

--- a/packages/openwrt/keen-pbr/files/usr/lib/keen-pbr/dnsmasq.sh
+++ b/packages/openwrt/keen-pbr/files/usr/lib/keen-pbr/dnsmasq.sh
@@ -156,7 +156,33 @@ uninstall_persistent() {
     restart_dnsmasq
 }
 
+resolver_config_hash_file() {
+    echo "${CACHE_DIR}/resolver-config.hash"
+}
+
+managed_conf_hash() {
+    # Hash the content of all keen-pbr managed dnsmasq conf files (sorted for determinism)
+    find /tmp/dnsmasq.*.d /tmp/dnsmasq.d -maxdepth 1 -name "${CONFFILE}" 2>/dev/null \
+        | sort | xargs cat 2>/dev/null | md5sum | awk '{print $1}'
+}
+
+dnsmasq_is_running() {
+    pidof dnsmasq >/dev/null 2>&1
+}
+
 restart_dnsmasq() {
+    hash_file="$(resolver_config_hash_file)"
+    new_hash="$(managed_conf_hash)"
+    old_hash=""
+    if [ -f "$hash_file" ]; then
+        old_hash="$(cat "$hash_file")"
+    fi
+    if [ "$new_hash" = "$old_hash" ] && dnsmasq_is_running; then
+        log_info "resolver config unchanged, skipping dnsmasq restart"
+        return 0
+    fi
+    mkdir -p "$CACHE_DIR"
+    printf '%s\n' "$new_hash" > "$hash_file"
     /etc/init.d/dnsmasq restart 2>/dev/null || true
 }
 


### PR DESCRIPTION
## Problem
keen-pbr restarted the system `dnsmasq` in full on every reload / activate / deactivate, even when the generated resolver config had not changed. A full restart is a multi-second window with no DNS service — on weak routers users see intermittent DNS failures whenever keen-pbr reloads (config edits, list refreshes, etc.).

## Change
Before performing the restart, the helper scripts fingerprint (`md5sum`) the **effective** dnsmasq config they would produce (active resolver config when active, fallback line when inactive) and compare it with the fingerprint stored from the previous run. If it is unchanged **and** dnsmasq is already running, the restart is skipped and an info line is logged instead. The first run, content changes, and activate/deactivate transitions all restart normally.

Applied consistently to the Keenetic, OpenWrt and Debian helper scripts.

## Testing
Shell-only change; POSIX sh / busybox-ash compatible. Backend test suite unaffected and green. Verified on a Keenetic KN-1011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
