### PR TITLE
perf: skip firewall reapply when the ruleset is unchanged

### DIFF
--- a/src/firewall/iptables.cpp
+++ b/src/firewall/iptables.cpp
@@ -1,6 +1,7 @@
 #include "iptables.hpp"
 #include "ipset_restore_pipe.hpp"
 #include "port_spec_util.hpp"
+#include "../crypto/md5.hpp"
 #include "../log/logger.hpp"
 #include "../util/format_compat.hpp"
 #include "../util/safe_exec.hpp"
@@ -398,22 +399,33 @@ void IptablesFirewall::apply(FirewallApplyMode mode) {
     // Phase 2: iptables rules via iptables-restore / ip6tables-restore.
     // Always materialize the KeenPbrTable scaffold for both protocols so
     // diagnostics can verify chain/jump presence even when no rules are needed.
-    bool has_v4 = true;
-    bool has_v6 = true;
-    for (const auto& pr : pending_rules_) {
-        if (pr.ipv6) has_v6 = true;
-        else has_v4 = true;
-    }
+    const std::string script_v4 =
+        build_ipt_script(false, pending_rules_, global_prefilter_);
+    const std::string script_v6 =
+        build_ipt_script(true, pending_rules_, global_prefilter_);
 
-    if (has_v4) {
-        pipe_to_cmd({"iptables-restore", "--noflush", "--counters"},
-                    build_ipt_script(false, pending_rules_, global_prefilter_));
+    // Fingerprint the generated ruleset text. On a PreserveSets refresh (the
+    // SIGUSR1 path), if the script is identical to the last successful apply we
+    // skip the iptables-restore subprocesses entirely: the live rules are
+    // already exactly what we would re-install. ipset membership is managed
+    // separately (Phase 1 above / dnsmasq) and is unaffected by this skip.
+    const std::string fingerprint =
+        crypto::md5_hex(script_v4 + "\n--ip6--\n" + script_v6);
+    const bool can_skip = mode == FirewallApplyMode::PreserveSets
+        && !last_applied_fingerprint_.empty()
+        && fingerprint == last_applied_fingerprint_;
+
+    if (can_skip) {
+        Logger::instance().trace(
+            "firewall_apply_skip",
+            "backend=iptables reason=ruleset-unchanged fingerprint={}",
+            fingerprint);
+    } else {
+        pipe_to_cmd({"iptables-restore", "--noflush", "--counters"}, script_v4);
         chain_v4_created_ = true;
-    }
-    if (has_v6) {
-        pipe_to_cmd({"ip6tables-restore", "--noflush", "--counters"},
-                    build_ipt_script(true, pending_rules_, global_prefilter_));
+        pipe_to_cmd({"ip6tables-restore", "--noflush", "--counters"}, script_v6);
         chain_v6_created_ = true;
+        last_applied_fingerprint_ = fingerprint;
     }
 
     // Clear pending buffers

--- a/src/firewall/iptables.hpp
+++ b/src/firewall/iptables.hpp
@@ -109,6 +109,12 @@ private:
     bool chain_v4_created_ = false;
     bool chain_v6_created_ = false;
 
+    // Fingerprint (MD5 hex) of the last successfully applied iptables-restore
+    // script pair. Empty until the first apply. Used to skip the expensive
+    // iptables-restore subprocess on PreserveSets refreshes when the generated
+    // ruleset text is byte-for-byte identical to what is already live.
+    std::string last_applied_fingerprint_;
+
 #ifdef KEEN_PBR3_TESTING
     friend class IptablesBuilderTest;
     // Allow test access to build_proto_port_fragment

--- a/src/firewall/nftables.cpp
+++ b/src/firewall/nftables.cpp
@@ -1,6 +1,7 @@
 #include "nftables.hpp"
 #include "nft_batch_pipe.hpp"
 #include "port_spec_util.hpp"
+#include "../crypto/md5.hpp"
 #include "../log/logger.hpp"
 #include "../util/format_compat.hpp"
 #include "../util/safe_exec.hpp"
@@ -612,6 +613,26 @@ void NftablesFirewall::apply(FirewallApplyMode mode) {
     std::string json_str = doc.dump();
     Logger::instance().verbose("nft json:\n{}", json_str);
 
+    // Fingerprint the generated nft batch. On a PreserveSets refresh (the
+    // SIGUSR1 path) that does not need a full-table restore, if the batch is
+    // identical to the last successful apply we skip the 'nft -j -f -'
+    // subprocess entirely: the live ruleset is already what we would
+    // re-install. Set membership is managed separately (by dnsmasq) and is
+    // unaffected by this skip.
+    const std::string fingerprint = crypto::md5_hex(json_str);
+    if (preserve_sets && !emit_full_table && !last_applied_fingerprint_.empty()
+        && fingerprint == last_applied_fingerprint_) {
+        Logger::instance().trace(
+            "firewall_apply_skip",
+            "backend=nftables reason=ruleset-unchanged fingerprint={}",
+            fingerprint);
+        pending_sets_.clear();
+        pending_elements_.clear();
+        pending_rules_.clear();
+        table_created_ = true;
+        return;
+    }
+
     // Apply atomically via nft -j -f -
     int status = safe_exec_pipe_stdin({"nft", "-j", "-f", "-"}, json_str);
     if (status != 0 && preserve_sets && !emit_full_table && !table_exists()) {
@@ -626,6 +647,11 @@ void NftablesFirewall::apply(FirewallApplyMode mode) {
     if (status != 0) {
         throw FirewallError(keen_pbr3::format("nft -j -f - exited with status {}", status));
     }
+
+    // Record the fingerprint of the batch that was actually applied. If the
+    // recovery path above ran, json_str now holds the full-table restore, so
+    // re-fingerprint it rather than reusing the value computed earlier.
+    last_applied_fingerprint_ = crypto::md5_hex(json_str);
 
     // Clear pending buffers
     pending_sets_.clear();

--- a/src/firewall/nftables.hpp
+++ b/src/firewall/nftables.hpp
@@ -130,6 +130,12 @@ private:
     // True once the inet KeenPbrTable table has been created via apply().
     bool table_created_ = false;
 
+    // Fingerprint (MD5 hex) of the last successfully applied nft JSON batch.
+    // Empty until the first apply. Used to skip the expensive 'nft -j -f -'
+    // subprocess on PreserveSets refreshes when the generated batch is
+    // byte-for-byte identical to what is already live.
+    std::string last_applied_fingerprint_;
+
 #ifdef KEEN_PBR3_TESTING
     friend class NftablesBuilderTest;
 #endif


### PR DESCRIPTION
## Problem
On Keenetic the netfilter.d hook raises `SIGUSR1` on every netfilter change — very frequently. Each signal made the daemon regenerate and reapply the **entire** firewall ruleset via `iptables-restore` / `nft -f`, even when the generated ruleset was byte-for-byte identical to what was already live. On weak MIPS routers this wastes CPU on every change.

## Change
Both firewall backends fingerprint (MD5) the generated ruleset text right before piping it to the subprocess, and remember the last successfully applied fingerprint. On a `PreserveSets` refresh (the SIGUSR1 path), if the fingerprint is unchanged the expensive subprocess apply is skipped. `Destructive` applies and the first apply always run.

`ipset` / `nftset` membership is managed separately (by dnsmasq) and is not part of the hashed rule text, so skipping the rule apply is safe; the skipped path leaves backend state identical to the applied path.

## Testing
Backend doctest suite green. Verified on a Keenetic KN-1011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
