### PR TITLE
perf(keenetic): keep HW NAT disabled and coalesce netfilter refresh bursts

### DIFF
--- a/packages/keenetic/keen-pbr/files/opt/etc/ndm/netfilter.d/50-keen-pbr-routing.sh
+++ b/packages/keenetic/keen-pbr/files/opt/etc/ndm/netfilter.d/50-keen-pbr-routing.sh
@@ -5,6 +5,20 @@
 logger -t "keen-pbr" "Refreshing routing state after netfilter change"
 /opt/etc/init.d/S80keen-pbr reapply-firewall >/dev/null 2>&1 || exit 0
 
+# Re-assert HW NAT (fastnat) is disabled after every netfilter change.
+# NDM re-enables it on network events, which silently breaks policy routing
+# because fastnat makes marked packets bypass the mangle table.
+# Hot-path cost: two sysctl reads; sysctl -w is skipped when already zero.
+for _key in net.ipv4.netfilter.ip_conntrack_fastnat net.netfilter.nf_conntrack_fastnat; do
+    _val="$(sysctl -n "$_key" 2>/dev/null)"
+    [ -z "$_val" ] && continue
+    if [ "$_val" != "0" ]; then
+        sysctl -w "$_key=0" 2>/dev/null || true
+        logger -t "keen-pbr" "Re-disabled HW NAT fastnat ($_key was $_val)"
+    fi
+done
+unset _key _val
+
 if [ -f /opt/etc/keen-pbr/hook.sh ]; then
     keen_pbr_hook="netfilter"
     . /opt/etc/keen-pbr/hook.sh

--- a/src/daemon/daemon_core.cpp
+++ b/src/daemon/daemon_core.cpp
@@ -30,7 +30,11 @@ namespace keen_pbr3 {
 
 namespace {
 
-constexpr auto SIGUSR1_DEBOUNCE_DELAY = std::chrono::milliseconds{150};
+// 500 ms gives weak Keenetic routers enough headroom to absorb a burst of
+// netfilter/NDM events before we pay the cost of a full firewall refresh.
+// The handler cancels-and-reschedules on every signal, so a burst collapses
+// into exactly one refresh once the storm settles.
+constexpr auto SIGUSR1_DEBOUNCE_DELAY = std::chrono::milliseconds{500};
 
 std::int64_t steady_duration_ms(std::chrono::steady_clock::time_point started_at) {
     return std::chrono::duration_cast<std::chrono::milliseconds>(


### PR DESCRIPTION
## Problem
On Keenetic, NDM fires a netfilter.d hook on every netfilter change. Two things made this churn harmful on weak routers:

1. **HW NAT (fastnat) gets silently re-enabled.** NDM turns fastnat back on during network events. fastnat offload makes marked packets bypass the `mangle` table, which breaks policy routing — and keen-pbr only disabled fastnat once, at service start.
2. **Frequent firewall refreshes.** Each hook invocation raises SIGUSR1; a burst of NDM events caused repeated refreshes.

## Change
- The `50-keen-pbr-routing.sh` netfilter.d hook now re-asserts that fastnat is disabled after every netfilter change. The hot path is just two `sysctl -n` reads; it only writes (and logs) when fastnat actually had to be flipped back off.
- The SIGUSR1 debounce window is widened 150ms → 500ms. The handler already coalesces a burst into a single refresh (cancel-and-reschedule per signal); the wider window absorbs NDM event storms into one refresh.

## Testing
Backend doctest suite green. Shell change is POSIX sh / busybox-ash compatible. Verified on a Keenetic KN-1011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
