### PR TITLE
feat: reroute established connections when a domain enters a routing set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,7 @@ set(SOURCES
   src/routing/target.cpp
   src/routing/netlink.cpp
   src/routing/interface_monitor.cpp
+  src/routing/conntrack_rerouter.cpp
   src/routing/route_table.cpp
   src/routing/policy_rule.cpp
   src/routing/routing_verifier.cpp

--- a/packages/debian/full/debian/control
+++ b/packages/debian/full/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/maksimkurb/keen-pbr
 
 Package: keen-pbr
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, dnsmasq
+Depends: ${shlibs:Depends}, ${misc:Depends}, dnsmasq, conntrack
 Suggests: xtables-addons-dkms
 Description: Policy-based routing daemon with REST API and Web UI
  keen-pbr routes traffic selectively by IPs, CIDRs, and domains.

--- a/packages/debian/headless/debian/control
+++ b/packages/debian/headless/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/maksimkurb/keen-pbr
 
 Package: keen-pbr-headless
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, dnsmasq
+Depends: ${shlibs:Depends}, ${misc:Depends}, dnsmasq, conntrack
 Suggests: xtables-addons-dkms
 Description: Policy-based routing daemon without REST API and Web UI
  keen-pbr routes traffic selectively by IPs, CIDRs, and domains.

--- a/packages/keenetic/keen-pbr/Makefile
+++ b/packages/keenetic/keen-pbr/Makefile
@@ -79,7 +79,7 @@ define Package/keen-pbr
   CATEGORY:=Network
   TITLE:=Keen Policy-Based Routing (full)
   VERSION:=$(PKG_VERSION)-$(PKG_RELEASE)
-  DEPENDS:=+conntrack-tools +dnsmasq +ipset +iptables +libatomic +libcurl +libnl-core +libnl-route +libstdcpp +zlib +libzstd
+  DEPENDS:=+conntrack +dnsmasq +ipset +iptables +libatomic +libcurl +libnl-core +libnl-route +libstdcpp +zlib +libzstd
   VARIANT:=full
 endef
 
@@ -135,7 +135,7 @@ define Package/keen-pbr-headless
   CATEGORY:=Network
   TITLE:=Keen Policy-Based Routing (headless)
   VERSION:=$(PKG_VERSION)-$(PKG_RELEASE)
-  DEPENDS:=+conntrack-tools +dnsmasq +ipset +iptables +libatomic +libcurl +libnl-core +libnl-route +libstdcpp +zlib +libzstd
+  DEPENDS:=+conntrack +dnsmasq +ipset +iptables +libatomic +libcurl +libnl-core +libnl-route +libstdcpp +zlib +libzstd
   VARIANT:=headless
 endef
 

--- a/packages/keenetic/keen-pbr/Makefile
+++ b/packages/keenetic/keen-pbr/Makefile
@@ -79,7 +79,7 @@ define Package/keen-pbr
   CATEGORY:=Network
   TITLE:=Keen Policy-Based Routing (full)
   VERSION:=$(PKG_VERSION)-$(PKG_RELEASE)
-  DEPENDS:=+dnsmasq +ipset +iptables +libatomic +libcurl +libnl-core +libnl-route +libstdcpp +zlib +libzstd
+  DEPENDS:=+conntrack-tools +dnsmasq +ipset +iptables +libatomic +libcurl +libnl-core +libnl-route +libstdcpp +zlib +libzstd
   VARIANT:=full
 endef
 
@@ -135,7 +135,7 @@ define Package/keen-pbr-headless
   CATEGORY:=Network
   TITLE:=Keen Policy-Based Routing (headless)
   VERSION:=$(PKG_VERSION)-$(PKG_RELEASE)
-  DEPENDS:=+dnsmasq +ipset +iptables +libatomic +libcurl +libnl-core +libnl-route +libstdcpp +zlib +libzstd
+  DEPENDS:=+conntrack-tools +dnsmasq +ipset +iptables +libatomic +libcurl +libnl-core +libnl-route +libstdcpp +zlib +libzstd
   VARIANT:=headless
 endef
 

--- a/packages/openwrt/keen-pbr/Makefile
+++ b/packages/openwrt/keen-pbr/Makefile
@@ -77,7 +77,7 @@ define Package/keen-pbr
   CATEGORY:=Network
   TITLE:=Keen Policy-Based Routing (full)
   VERSION:=$(if $(CONFIG_USE_APK),$(PKG_VERSION)-r$(PKG_RELEASE),$(PKG_VERSION)-$(PKG_RELEASE))
-  DEPENDS:=+dnsmasq-full +libatomic +libcurl +libnl-core +libnl-route +libstdcpp +zlib +libzstd
+  DEPENDS:=+conntrack +dnsmasq-full +libatomic +libcurl +libnl-core +libnl-route +libstdcpp +zlib +libzstd
   VARIANT:=full
 endef
 
@@ -129,7 +129,7 @@ define Package/keen-pbr-headless
   CATEGORY:=Network
   TITLE:=Keen Policy-Based Routing (headless)
   VERSION:=$(if $(CONFIG_USE_APK),$(PKG_VERSION)-r$(PKG_RELEASE),$(PKG_VERSION)-$(PKG_RELEASE))
-  DEPENDS:=+dnsmasq-full +libatomic +libcurl +libnl-core +libnl-route +libstdcpp +zlib +libzstd
+  DEPENDS:=+conntrack +dnsmasq-full +libatomic +libcurl +libnl-core +libnl-route +libstdcpp +zlib +libzstd
   VARIANT:=headless
 endef
 

--- a/src/daemon/daemon.hpp
+++ b/src/daemon/daemon.hpp
@@ -18,6 +18,7 @@
 #include "config_store.hpp"
 #include "../health/url_tester.hpp"
 #include "../routing/interface_monitor.hpp"
+#include "../routing/conntrack_rerouter.hpp"
 #include "../routing/firewall_state.hpp"
 #include "../routing/netlink.hpp"
 #include "../routing/policy_rule.hpp"
@@ -197,6 +198,7 @@ private:
     void schedule_resolver_config_hash_actual_retry();
     void schedule_keenetic_dns_refresh();
     bool refresh_keenetic_dns_cache(bool force_refresh);
+    void schedule_conntrack_reroute();
     void reset_resolver_actual_state();
     void commit_resolver_hash_probe_result(const std::string& resolver_addr,
                                            std::uint64_t generation,
@@ -260,6 +262,9 @@ private:
     int resolver_config_hash_actual_retry_task_id_{-1};
     // Debounced runtime refresh triggered by SIGUSR1.
     int sigusr1_refresh_task_id_{-1};
+    // Periodic conntrack reroute poll: flushes stale connections when a new
+    // IP enters a dnsmasq-populated routing set.
+    int conntrack_reroute_task_id_{-1};
 
     // Epoll state
     int epoll_fd_{-1};
@@ -313,6 +318,7 @@ private:
     OutboundMarkMap outbound_marks_;
     std::unique_ptr<Scheduler> scheduler_;
     std::unique_ptr<UrltestManager> urltest_manager_;
+    std::unique_ptr<ConntrackRerouter> conntrack_rerouter_;
     BlockingExecutor blocking_executor_{2, 64};
     std::atomic<std::uint64_t> runtime_generation_{1};
     std::atomic<bool> remote_list_refresh_inflight_{false};

--- a/src/daemon/daemon_runtime.cpp
+++ b/src/daemon/daemon_runtime.cpp
@@ -22,10 +22,12 @@ namespace keen_pbr3 {
 namespace {
 
 // How often to scan the dnsmasq-populated routing sets for newly added IPs
-// and flush their stale conntrack entries. Short enough that a freshly
-// resolved domain starts routing correctly within a few seconds, cheap
-// enough (one small `ipset save`/`nft list set` per set) for weak routers.
-constexpr auto CONNTRACK_REROUTE_INTERVAL = std::chrono::seconds{5};
+// and flush their stale conntrack entries. 20s keeps a freshly resolved
+// domain re-routing within one short interval while staying cheap on weak
+// MIPS routers: a config with dozens of lists would otherwise fork one
+// `ipset save` per set far too often. The poll is also scoped to the sets
+// of *enabled* route rules only (see schedule_conntrack_reroute).
+constexpr auto CONNTRACK_REROUTE_INTERVAL = std::chrono::seconds{20};
 
 std::string format_list_names(const std::vector<std::string>& list_names) {
     if (list_names.empty()) {
@@ -273,18 +275,25 @@ void Daemon::schedule_conntrack_reroute() {
         conntrack_reroute_task_id_ = -1;
     }
 
-    // Watch the dnsmasq-populated dynamic sets of every list that can carry
-    // domains. A pure ip_cidrs list has no dynamic set, so polling it is
-    // pointless; url/file lists may contain domains, so they are included.
-    std::vector<std::string> set_names;
-    for (const auto& [list_name, list_cfg] :
-         config_.lists.value_or(std::map<std::string, ListConfig>{})) {
-        const bool may_have_domains = list_cfg.domains.has_value() ||
-                                      list_cfg.url.has_value() ||
-                                      list_cfg.file.has_value();
-        if (!may_have_domains) {
-            continue;
+    // Only lists referenced by an *enabled* route rule actually carry
+    // policy-routed traffic, so they are the only dynamic sets whose new
+    // members need a conntrack flush. Scoping to them (instead of every list
+    // that might hold domains) keeps the poll cheap on configs with dozens
+    // of lists.
+    std::set<std::string> routed_lists;
+    if (config_.route.has_value() && config_.route->rules.has_value()) {
+        for (const auto& rule : *config_.route->rules) {
+            if (!route_rule_enabled(rule)) {
+                continue;
+            }
+            for (const auto& list_name : route_rule_lists(rule)) {
+                routed_lists.insert(list_name);
+            }
         }
+    }
+
+    std::vector<std::string> set_names;
+    for (const auto& list_name : routed_lists) {
         set_names.push_back(DnsmasqGenerator::ipset_name_v4(list_name));
         set_names.push_back(DnsmasqGenerator::ipset_name_v6(list_name));
     }

--- a/src/daemon/daemon_runtime.cpp
+++ b/src/daemon/daemon_runtime.cpp
@@ -6,10 +6,12 @@
 #include <sstream>
 
 #include "../config/routing_state.hpp"
+#include "../dns/dnsmasq_gen.hpp"
 #include "../firewall/firewall.hpp"
 #include "../firewall/firewall_runtime.hpp"
 #include "../log/logger.hpp"
 #include "../routing/urltest_manager.hpp"
+#include "../util/firewall_backend_utils.hpp"
 #include "../util/time_utils.hpp"
 #include "../util/cron.hpp"
 #include "scheduler.hpp"
@@ -18,6 +20,12 @@
 namespace keen_pbr3 {
 
 namespace {
+
+// How often to scan the dnsmasq-populated routing sets for newly added IPs
+// and flush their stale conntrack entries. Short enough that a freshly
+// resolved domain starts routing correctly within a few seconds, cheap
+// enough (one small `ipset save`/`nft list set` per set) for weak routers.
+constexpr auto CONNTRACK_REROUTE_INTERVAL = std::chrono::seconds{5};
 
 std::string format_list_names(const std::vector<std::string>& list_names) {
     if (list_names.empty()) {
@@ -259,6 +267,64 @@ void Daemon::schedule_lists_autoupdate() {
     Logger::instance().info("Lists autoupdate scheduled (next: ~{}s)", delay.count());
 }
 
+void Daemon::schedule_conntrack_reroute() {
+    if (conntrack_reroute_task_id_ >= 0) {
+        scheduler_->cancel(conntrack_reroute_task_id_);
+        conntrack_reroute_task_id_ = -1;
+    }
+
+    // Watch the dnsmasq-populated dynamic sets of every list that can carry
+    // domains. A pure ip_cidrs list has no dynamic set, so polling it is
+    // pointless; url/file lists may contain domains, so they are included.
+    std::vector<std::string> set_names;
+    for (const auto& [list_name, list_cfg] :
+         config_.lists.value_or(std::map<std::string, ListConfig>{})) {
+        const bool may_have_domains = list_cfg.domains.has_value() ||
+                                      list_cfg.url.has_value() ||
+                                      list_cfg.file.has_value();
+        if (!may_have_domains) {
+            continue;
+        }
+        set_names.push_back(DnsmasqGenerator::ipset_name_v4(list_name));
+        set_names.push_back(DnsmasqGenerator::ipset_name_v6(list_name));
+    }
+
+    if (set_names.empty()) {
+        conntrack_rerouter_.reset();
+        return;
+    }
+
+    // Recreate the rerouter so its baseline starts fresh after a config apply
+    // (the firewall, and therefore its sets, was just rebuilt).
+    const FirewallBackend backend =
+        resolve_firewall_backend(firewall_backend_preference(config_));
+    DynamicSetReader reader = backend == FirewallBackend::nftables
+                                  ? DynamicSetReader(&read_nft_dynamic_sets)
+                                  : DynamicSetReader(&read_ipset_dynamic_sets);
+    conntrack_rerouter_ =
+        std::make_unique<ConntrackRerouter>(std::move(reader), &flush_conntrack_for_ip);
+
+    conntrack_reroute_task_id_ = scheduler_->schedule_repeating(
+        CONNTRACK_REROUTE_INTERVAL,
+        [this, set_names]() {
+            post_control_task(
+                [this, set_names]() {
+                    if (!routing_runtime_active_ || !conntrack_rerouter_) {
+                        return;
+                    }
+                    const std::size_t flushed = conntrack_rerouter_->poll(set_names);
+                    if (flushed > 0) {
+                        Logger::instance().info(
+                            "conntrack reroute: flushed {} stale connection(s) "
+                            "for newly routed IP(s)",
+                            flushed);
+                    }
+                },
+                "conntrack-reroute");
+        },
+        "conntrack-reroute");
+}
+
 ListsRefreshExecutionResult Daemon::execute_remote_list_refresh(
     const std::set<std::string>* target_lists) {
     auto& log = Logger::instance();
@@ -479,6 +545,10 @@ void Daemon::apply_prepared_runtime_inputs(PreparedRuntimeInputs prepared) {
         scheduler_->cancel(resolver_config_hash_actual_retry_task_id_);
         resolver_config_hash_actual_retry_task_id_ = -1;
     }
+    if (conntrack_reroute_task_id_ >= 0) {
+        scheduler_->cancel(conntrack_reroute_task_id_);
+        conntrack_reroute_task_id_ = -1;
+    }
 
     outbound_marks_ = std::move(prepared.outbound_marks);
     config_ = std::move(prepared.config);
@@ -497,6 +567,7 @@ void Daemon::apply_prepared_runtime_inputs(PreparedRuntimeInputs prepared) {
     (void)refresh_keenetic_dns_cache(true);
     apply_firewall(FirewallApplyMode::Destructive);
     schedule_keenetic_dns_refresh();
+    schedule_conntrack_reroute();
     schedule_lists_autoupdate();
     update_resolver_config_hash();
     setup_dns_probe();

--- a/src/routing/conntrack_rerouter.cpp
+++ b/src/routing/conntrack_rerouter.cpp
@@ -1,0 +1,206 @@
+#include "conntrack_rerouter.hpp"
+
+#include "../log/logger.hpp"
+#include "../util/safe_exec.hpp"
+
+#include <atomic>
+#include <mutex>
+#include <sstream>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+namespace keen_pbr3 {
+
+namespace {
+
+// nft table that owns keen-pbr's sets. Mirrors NftablesFirewall::TABLE_NAME;
+// duplicated as a literal to avoid pulling the whole nftables backend header.
+constexpr const char* kNftTableName = "KeenPbrTable";
+
+// Extracts a plain-IP element value from one entry of an nft set "elem" array.
+// Entries are either bare strings ("1.2.3.4") or, for timeout sets, objects of
+// the shape {"elem": {"val": "1.2.3.4", ...}}. Range/prefix elements (objects
+// instead of a string val) are skipped -- dynamic sets only hold single IPs.
+std::string extract_nft_elem_ip(const nlohmann::json& entry) {
+    if (entry.is_string()) {
+        return entry.get<std::string>();
+    }
+    if (entry.is_object()) {
+        const auto elem_it = entry.find("elem");
+        if (elem_it != entry.end()) {
+            return extract_nft_elem_ip(*elem_it);
+        }
+        const auto val_it = entry.find("val");
+        if (val_it != entry.end() && val_it->is_string()) {
+            return val_it->get<std::string>();
+        }
+    }
+    return {};
+}
+
+} // namespace
+
+ConntrackRerouter::ConntrackRerouter(DynamicSetReader reader, ConntrackFlusher flusher)
+    : reader_(std::move(reader)), flusher_(std::move(flusher)) {}
+
+void ConntrackRerouter::reset() {
+    known_members_.clear();
+}
+
+std::size_t ConntrackRerouter::poll(const std::vector<std::string>& set_names) {
+    if (set_names.empty() || !reader_ || !flusher_) {
+        return 0;
+    }
+
+    const auto current = reader_(set_names);
+
+    std::size_t flushed = 0;
+    std::set<std::string> observed;
+
+    for (const auto& [set_name, members] : current) {
+        observed.insert(set_name);
+        std::set<std::string> now(members.begin(), members.end());
+
+        const auto known_it = known_members_.find(set_name);
+        if (known_it == known_members_.end()) {
+            // First observation of this set: record a silent baseline so we do
+            // not flush conntrack for every pre-existing member at startup.
+            known_members_.emplace(set_name, std::move(now));
+            continue;
+        }
+
+        for (const auto& ip : now) {
+            if (known_it->second.count(ip) == 0) {
+                flusher_(ip);
+                ++flushed;
+            }
+        }
+        known_it->second = std::move(now);
+    }
+
+    // Drop baselines for sets that are no longer present, so that if such a
+    // set reappears later it is re-baselined rather than diffed against stale
+    // membership.
+    for (auto it = known_members_.begin(); it != known_members_.end();) {
+        if (observed.count(it->first) == 0) {
+            it = known_members_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    return flushed;
+}
+
+std::map<std::string, std::vector<std::string>>
+read_ipset_dynamic_sets(const std::vector<std::string>& set_names) {
+    std::map<std::string, std::vector<std::string>> result;
+
+    for (const auto& set_name : set_names) {
+        const auto capture =
+            safe_exec_capture({"ipset", "save", set_name}, /*suppress_stderr=*/true);
+        if (capture.exit_code != 0) {
+            // Set does not exist yet (no domains resolved into it). Skip it;
+            // poll() will baseline it once it appears.
+            continue;
+        }
+
+        std::vector<std::string> members;
+        std::istringstream stream(capture.stdout_output);
+        std::string line;
+        while (std::getline(stream, line)) {
+            // Lines look like: "add <set> <ip> [timeout N ...]"
+            std::istringstream line_stream(line);
+            std::string verb;
+            std::string parsed_set;
+            std::string member;
+            if (line_stream >> verb >> parsed_set >> member && verb == "add"
+                && parsed_set == set_name && !member.empty()) {
+                members.push_back(member);
+            }
+        }
+        result.emplace(set_name, std::move(members));
+    }
+
+    return result;
+}
+
+std::map<std::string, std::vector<std::string>>
+read_nft_dynamic_sets(const std::vector<std::string>& set_names) {
+    std::map<std::string, std::vector<std::string>> result;
+
+    for (const auto& set_name : set_names) {
+        const auto capture = safe_exec_capture(
+            {"nft", "-j", "list", "set", "inet", kNftTableName, set_name},
+            /*suppress_stderr=*/true);
+        if (capture.exit_code != 0 || capture.stdout_output.empty()) {
+            continue; // Set does not exist yet.
+        }
+
+        nlohmann::json doc = nlohmann::json::parse(capture.stdout_output, nullptr, false);
+        if (doc.is_discarded() || !doc.is_object()) {
+            continue;
+        }
+        const auto nft_it = doc.find("nftables");
+        if (nft_it == doc.end() || !nft_it->is_array()) {
+            continue;
+        }
+
+        std::vector<std::string> members;
+        for (const auto& node : *nft_it) {
+            const auto set_it = node.find("set");
+            if (set_it == node.end() || !set_it->is_object()) {
+                continue;
+            }
+            const auto elem_it = set_it->find("elem");
+            if (elem_it == set_it->end() || !elem_it->is_array()) {
+                continue;
+            }
+            for (const auto& entry : *elem_it) {
+                std::string ip = extract_nft_elem_ip(entry);
+                if (!ip.empty()) {
+                    members.push_back(std::move(ip));
+                }
+            }
+        }
+        result.emplace(set_name, std::move(members));
+    }
+
+    return result;
+}
+
+void flush_conntrack_for_ip(const std::string& ip) {
+    static std::atomic<bool> conntrack_unavailable{false};
+    static std::once_flag probe_flag;
+
+    std::call_once(probe_flag, []() {
+        const int rc = safe_exec({"conntrack", "--version"}, /*suppress_output=*/true);
+        // 127 == exec failed (command not found). Anything else means the tool
+        // ran, so it is usable.
+        if (rc == 127 || rc < 0) {
+            conntrack_unavailable.store(true, std::memory_order_relaxed);
+            Logger::instance().warn(
+                "conntrack tool not found; stale-connection rerouting is "
+                "disabled. Install conntrack-tools to enable it.");
+        }
+    });
+
+    if (conntrack_unavailable.load(std::memory_order_relaxed) || ip.empty()) {
+        return;
+    }
+
+    std::vector<std::string> args = {"conntrack", "-D"};
+    if (ip.find(':') != std::string::npos) {
+        args.push_back("-f");
+        args.push_back("ipv6");
+    }
+    args.push_back("-d");
+    args.push_back(ip);
+
+    // conntrack -D exits non-zero when nothing matched, which is normal and
+    // expected; suppress its output and ignore the status.
+    (void)safe_exec(args, /*suppress_output=*/true);
+}
+
+} // namespace keen_pbr3

--- a/src/routing/conntrack_rerouter.hpp
+++ b/src/routing/conntrack_rerouter.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace keen_pbr3 {
+
+// keen-pbr routes domain-based traffic by letting dnsmasq add resolved IPs to
+// "dynamic" ipsets/nft sets (kpbr4d_* / kpbr6d_*). The firewall marks packets
+// whose destination is in such a set, and the mark selects a routing table.
+//
+// The mark is evaluated on the first packet of a flow; once conntrack has
+// confirmed the flow it keeps following the original (unmarked) path. So a
+// connection that was established *before* a domain's IP entered the set --
+// or that raced the set update -- keeps bypassing policy routing for its whole
+// lifetime. This is the classic "the route is configured but traffic still
+// goes out the wrong interface" symptom.
+//
+// ConntrackRerouter watches the dynamic sets and, when a new IP appears,
+// flushes the stale conntrack entries for it so the next packet re-traverses
+// the mangle table and picks up the correct mark/route.
+//
+// The class itself is pure logic: I/O (reading sets, flushing conntrack) is
+// injected, which keeps it unit-testable. Default production implementations
+// are provided as free functions below.
+
+// Reads the current members of the named dynamic routing sets.
+// Returns set-name -> member IPs. Sets that do not exist are simply omitted.
+using DynamicSetReader = std::function<
+    std::map<std::string, std::vector<std::string>>(const std::vector<std::string>&)>;
+
+// Flushes conntrack entries whose original-direction destination is `ip`.
+using ConntrackFlusher = std::function<void(const std::string& ip)>;
+
+class ConntrackRerouter {
+public:
+    ConntrackRerouter(DynamicSetReader reader, ConntrackFlusher flusher);
+
+    // Run one poll cycle over the given dynamic set names. For every IP that
+    // appeared since the previous poll, the conntrack flusher is invoked.
+    // Returns the number of IPs flushed.
+    //
+    // The first time a set is observed its members are recorded as a silent
+    // baseline (nothing is flushed) so that startup -- when every set looks
+    // "new" -- does not trigger a flush storm.
+    std::size_t poll(const std::vector<std::string>& set_names);
+
+    // Forget every baseline. The next poll re-baselines all sets. Call this
+    // after a config reload, when the firewall (and its sets) was rebuilt.
+    void reset();
+
+private:
+    DynamicSetReader reader_;
+    ConntrackFlusher flusher_;
+    std::map<std::string, std::set<std::string>> known_members_;
+};
+
+// Production DynamicSetReader for the iptables/ipset backend (parses
+// `ipset save <name>` for each set).
+std::map<std::string, std::vector<std::string>>
+read_ipset_dynamic_sets(const std::vector<std::string>& set_names);
+
+// Production DynamicSetReader for the nftables backend (parses
+// `nft -j list set inet KeenPbrTable <name>` for each set).
+std::map<std::string, std::vector<std::string>>
+read_nft_dynamic_sets(const std::vector<std::string>& set_names);
+
+// Production ConntrackFlusher: invokes the `conntrack` tool. The tool is
+// probed once on first use; if it is unavailable a single warning is logged
+// and all further calls become no-ops.
+void flush_conntrack_for_ip(const std::string& ip);
+
+} // namespace keen_pbr3

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(keen-pbr-tests
   test_http_client.cpp
   test_config_validation.cpp
   test_routing_state.cpp
+  test_conntrack_rerouter.cpp
   test_runtime_interface_inventory.cpp
   test_api_runtime_interfaces.cpp
   test_api_static.cpp
@@ -65,6 +66,7 @@ add_executable(keen-pbr-tests
   ../src/util/traced_mutex.cpp
   ../src/routing/policy_rule.cpp
   ../src/routing/route_table.cpp
+  ../src/routing/conntrack_rerouter.cpp
   ../src/routing/target.cpp
 )
 set_target_properties(keen-pbr-tests PROPERTIES

--- a/tests/test_conntrack_rerouter.cpp
+++ b/tests/test_conntrack_rerouter.cpp
@@ -1,0 +1,150 @@
+#include <doctest/doctest.h>
+
+#include "../src/routing/conntrack_rerouter.hpp"
+
+#include <map>
+#include <string>
+#include <vector>
+
+using namespace keen_pbr3;
+
+namespace {
+
+// A scriptable DynamicSetReader: each poll consumes the next canned snapshot.
+struct FakeSetSource {
+    std::vector<std::map<std::string, std::vector<std::string>>> snapshots;
+    std::size_t next = 0;
+
+    std::map<std::string, std::vector<std::string>> read(
+        const std::vector<std::string>& /*set_names*/) {
+        if (next >= snapshots.size()) {
+            return {};
+        }
+        return snapshots[next++];
+    }
+};
+
+} // namespace
+
+TEST_CASE("ConntrackRerouter: first poll baselines without flushing") {
+    FakeSetSource source;
+    source.snapshots = {
+        {{"kpbr4d_a", {"1.1.1.1", "2.2.2.2"}}},
+    };
+    std::vector<std::string> flushed;
+
+    ConntrackRerouter rerouter(
+        [&](const std::vector<std::string>& n) { return source.read(n); },
+        [&](const std::string& ip) { flushed.push_back(ip); });
+
+    const std::size_t count = rerouter.poll({"kpbr4d_a"});
+    CHECK(count == 0);
+    CHECK(flushed.empty());
+}
+
+TEST_CASE("ConntrackRerouter: flushes only IPs added after the baseline") {
+    FakeSetSource source;
+    source.snapshots = {
+        {{"kpbr4d_a", {"1.1.1.1"}}},                          // baseline
+        {{"kpbr4d_a", {"1.1.1.1", "3.3.3.3"}}},               // 3.3.3.3 is new
+        {{"kpbr4d_a", {"1.1.1.1", "3.3.3.3"}}},               // nothing new
+    };
+    std::vector<std::string> flushed;
+
+    ConntrackRerouter rerouter(
+        [&](const std::vector<std::string>& n) { return source.read(n); },
+        [&](const std::string& ip) { flushed.push_back(ip); });
+
+    CHECK(rerouter.poll({"kpbr4d_a"}) == 0);
+    CHECK(rerouter.poll({"kpbr4d_a"}) == 1);
+    CHECK(rerouter.poll({"kpbr4d_a"}) == 0);
+
+    REQUIRE(flushed.size() == 1);
+    CHECK(flushed[0] == "3.3.3.3");
+}
+
+TEST_CASE("ConntrackRerouter: an IP that leaves and returns is flushed again") {
+    FakeSetSource source;
+    source.snapshots = {
+        {{"kpbr4d_a", {"9.9.9.9"}}},   // baseline
+        {{"kpbr4d_a", {}}},            // 9.9.9.9 expired out
+        {{"kpbr4d_a", {"9.9.9.9"}}},   // resolved again -> treated as new
+    };
+    std::vector<std::string> flushed;
+
+    ConntrackRerouter rerouter(
+        [&](const std::vector<std::string>& n) { return source.read(n); },
+        [&](const std::string& ip) { flushed.push_back(ip); });
+
+    rerouter.poll({"kpbr4d_a"});
+    rerouter.poll({"kpbr4d_a"});
+    CHECK(rerouter.poll({"kpbr4d_a"}) == 1);
+    REQUIRE(flushed.size() == 1);
+    CHECK(flushed[0] == "9.9.9.9");
+}
+
+TEST_CASE("ConntrackRerouter: reset re-baselines so nothing is flushed next poll") {
+    FakeSetSource source;
+    source.snapshots = {
+        {{"kpbr4d_a", {"1.1.1.1"}}},
+        {{"kpbr4d_a", {"1.1.1.1", "2.2.2.2"}}},
+    };
+    std::vector<std::string> flushed;
+
+    ConntrackRerouter rerouter(
+        [&](const std::vector<std::string>& n) { return source.read(n); },
+        [&](const std::string& ip) { flushed.push_back(ip); });
+
+    rerouter.poll({"kpbr4d_a"});
+    rerouter.reset();
+    // After reset the next poll is a fresh baseline even though 2.2.2.2 is new
+    // relative to the pre-reset snapshot.
+    CHECK(rerouter.poll({"kpbr4d_a"}) == 0);
+    CHECK(flushed.empty());
+}
+
+TEST_CASE("ConntrackRerouter: tracks multiple sets independently") {
+    FakeSetSource source;
+    source.snapshots = {
+        {{"kpbr4d_a", {"1.1.1.1"}}, {"kpbr6d_a", {"2001:db8::1"}}},
+        {{"kpbr4d_a", {"1.1.1.1", "4.4.4.4"}}, {"kpbr6d_a", {"2001:db8::1"}}},
+    };
+    std::vector<std::string> flushed;
+
+    ConntrackRerouter rerouter(
+        [&](const std::vector<std::string>& n) { return source.read(n); },
+        [&](const std::string& ip) { flushed.push_back(ip); });
+
+    rerouter.poll({"kpbr4d_a", "kpbr6d_a"});
+    CHECK(rerouter.poll({"kpbr4d_a", "kpbr6d_a"}) == 1);
+    REQUIRE(flushed.size() == 1);
+    CHECK(flushed[0] == "4.4.4.4");
+}
+
+TEST_CASE("ConntrackRerouter: a set that disappears is re-baselined when it returns") {
+    FakeSetSource source;
+    source.snapshots = {
+        {{"kpbr4d_a", {"1.1.1.1"}}},   // baseline
+        {},                            // set absent this poll (reader omitted it)
+        {{"kpbr4d_a", {"1.1.1.1"}}},   // back again -> fresh baseline, no flush
+    };
+    std::vector<std::string> flushed;
+
+    ConntrackRerouter rerouter(
+        [&](const std::vector<std::string>& n) { return source.read(n); },
+        [&](const std::string& ip) { flushed.push_back(ip); });
+
+    rerouter.poll({"kpbr4d_a"});
+    rerouter.poll({"kpbr4d_a"});
+    CHECK(rerouter.poll({"kpbr4d_a"}) == 0);
+    CHECK(flushed.empty());
+}
+
+TEST_CASE("ConntrackRerouter: empty set name list is a no-op") {
+    ConntrackRerouter rerouter(
+        [](const std::vector<std::string>&) {
+            return std::map<std::string, std::vector<std::string>>{};
+        },
+        [](const std::string&) {});
+    CHECK(rerouter.poll({}) == 0);
+}


### PR DESCRIPTION
## Problem
Domain-based routing relies on dnsmasq adding resolved IPs to the dynamic `kpbr*d_` ipsets / nft sets; the firewall then marks packets whose destination is in such a set. The mark is evaluated on the **first packet** of a flow, so:

- a connection established **before** a domain's IP entered the set, or
- a connection that **raced** the set update,

keeps following its original (unmarked) path for its entire lifetime — conntrack has already confirmed the flow. This is the long-standing *"the route is configured but traffic still goes out the wrong interface"* symptom, and it does not self-heal.

## Change
Add `ConntrackRerouter` — a periodic poller that snapshots the dynamic routing sets and, when a **new IP appears**, flushes the stale conntrack entries for it (`conntrack -D -d <ip>`) so the next packet re-traverses the mangle table and picks up the correct route.

- The first observation of each set is a silent **baseline** — no startup flush storm.
- The poll is **scoped to the sets of enabled route rules only** and runs every 20s; on a config with dozens of lists this keeps it cheap on weak MIPS CPUs (one small `ipset save` / `nft list set` per relevant set).
- The `conntrack` tool is probed once; if absent the feature disables itself with a single warning. Packages declare the dependency (`conntrack` on OpenWrt/Keenetic-Entware/Debian).

## Testing
Backend doctest incl. new `ConntrackRerouter` unit tests covering the baseline/diff logic — green. Verified on a Keenetic KN-1011 (the set parsers and `conntrack` invocation are thin wrappers over external tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
