### PR TITLE
fix(daemon): reconnect the interface monitor after netlink errors

### DIFF
--- a/src/daemon/daemon_core.cpp
+++ b/src/daemon/daemon_core.cpp
@@ -449,6 +449,37 @@ void Daemon::handle_interface_monitor_events(uint32_t events) {
         interface_monitor_->handle_events();
     } catch (const std::exception& e) {
         Logger::instance().error("Interface monitor event handling failed: {}", e.what());
+
+        int old_fd = -1;
+        try {
+            old_fd = interface_monitor_->fd();
+        } catch (const std::exception&) {
+            // socket already gone; nothing to unregister
+        }
+
+        try {
+            interface_monitor_->reconnect();
+            // reconnect() builds a fresh netlink socket with a NEW fd and
+            // closes the old one. epoll and fd_entries_ must be updated, or
+            // interface events stop being delivered. Always unregister the
+            // old fd first: even when the new socket reuses the same fd
+            // number, this drops the now-stale fd_entries_ row before the
+            // fresh one is appended (remove is queued ahead of add).
+            const int new_fd = interface_monitor_->fd();
+            if (old_fd >= 0) {
+                remove_fd(old_fd, /*wait_for_completion=*/false,
+                          "interface-monitor-stale");
+            }
+            add_fd(new_fd,
+                   EPOLLIN,
+                   [this](uint32_t ev) { handle_interface_monitor_events(ev); },
+                   /*wait_for_completion=*/false,
+                   "interface-monitor");
+            Logger::instance().warn("Interface monitor reconnected after netlink error");
+        } catch (const std::exception& reconnect_error) {
+            Logger::instance().error("Interface monitor reconnect failed: {}",
+                                     reconnect_error.what());
+        }
     }
 }
 

--- a/src/routing/interface_monitor.cpp
+++ b/src/routing/interface_monitor.cpp
@@ -94,34 +94,45 @@ struct InterfaceMonitor::Impl {
     InterfaceStateCallback callback;
     struct nl_sock* socket{nullptr};
     std::unordered_map<std::string, bool> interface_state;
+
+    void setup_socket() {
+        if (socket) {
+            nl_close(socket);
+            nl_socket_free(socket);
+            socket = nullptr;
+        }
+
+        socket = nl_socket_alloc();
+        if (!socket) {
+            throw InterfaceMonitorError(
+                "Failed to allocate netlink socket for interface monitor");
+        }
+
+        int err = nl_connect(socket, NETLINK_ROUTE);
+        if (err < 0) {
+            throw InterfaceMonitorError(format(
+                "Failed to connect interface monitor netlink socket: {}", nl_geterror(err)));
+        }
+
+        err = nl_socket_add_memberships(socket, RTNLGRP_LINK, 0);
+        if (err < 0) {
+            throw InterfaceMonitorError(format(
+                "Failed to subscribe interface monitor to link group: {}", nl_geterror(err)));
+        }
+
+        nl_socket_set_nonblocking(socket);
+        nl_socket_disable_seq_check(socket);
+        nl_socket_modify_cb(socket,
+                            NL_CB_VALID,
+                            NL_CB_CUSTOM,
+                            &InterfaceMonitor::Impl::on_nl_message,
+                            this);
+    }
 };
 
 InterfaceMonitor::InterfaceMonitor(InterfaceStateCallback callback)
     : impl_(std::make_unique<Impl>(std::move(callback))) {
-    impl_->socket = nl_socket_alloc();
-    if (!impl_->socket) {
-        throw InterfaceMonitorError("Failed to allocate netlink socket for interface monitor");
-    }
-
-    int err = nl_connect(impl_->socket, NETLINK_ROUTE);
-    if (err < 0) {
-        throw InterfaceMonitorError(
-            format("Failed to connect interface monitor netlink socket: {}", nl_geterror(err)));
-    }
-
-    err = nl_socket_add_memberships(impl_->socket, RTNLGRP_LINK, 0);
-    if (err < 0) {
-        throw InterfaceMonitorError(
-            format("Failed to subscribe interface monitor to link group: {}", nl_geterror(err)));
-    }
-
-    nl_socket_set_nonblocking(impl_->socket);
-    nl_socket_disable_seq_check(impl_->socket);
-    nl_socket_modify_cb(impl_->socket,
-                        NL_CB_VALID,
-                        NL_CB_CUSTOM,
-                        &InterfaceMonitor::Impl::on_nl_message,
-                        impl_.get());
+    impl_->setup_socket();
 }
 
 InterfaceMonitor::~InterfaceMonitor() = default;
@@ -151,6 +162,14 @@ void InterfaceMonitor::handle_events() {
         throw InterfaceMonitorError(
             format("Failed to receive interface monitor netlink messages: {}", nl_geterror(err)));
     }
+}
+
+void InterfaceMonitor::reconnect() {
+    if (!impl_) {
+        return;
+    }
+
+    impl_->setup_socket();
 }
 
 } // namespace keen_pbr3

--- a/src/routing/interface_monitor.hpp
+++ b/src/routing/interface_monitor.hpp
@@ -27,6 +27,9 @@ public:
     int fd() const;
     void handle_events();
 
+    // Rebuild the netlink subscription after a recoverable receive error.
+    void reconnect();
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;


### PR DESCRIPTION
## Problem

When the interface-monitor netlink socket hits a recoverable error, the daemon stops receiving interface up/down events entirely — policy routing then no longer refreshes when a link goes up or down.

## Fix

On a netlink error, rebuild the socket. `reconnect()` opens a fresh netlink socket with a new fd; the old fd is unregistered from epoll and from the daemon's `fd_entries_` table, and the new fd is registered — all through the existing thread-safe control-task queue.

The old fd is **always** unregistered before the new one is added (remove is queued ahead of add), so even when the kernel hands the new socket the same fd number, no stale handle is left behind in `fd_entries_`. This addresses the concern about old handles being reused after a reconnect that was raised in the review of #125.

## Testing

Full doctest suite passes. Verified on a Keenetic KN-1011 (MT7621).