### PR TITLE
fix(lists): keep file and inline entries when a list has a cached URL

### DIFF
--- a/src/lists/list_streamer.cpp
+++ b/src/lists/list_streamer.cpp
@@ -9,40 +9,47 @@ namespace keen_pbr3 {
 ListStreamer::ListStreamer(const CacheManager& cache) : cache_(cache) {}
 
 void ListStreamer::stream_list(const std::string& name, const ListConfig& config, ListEntryVisitor& visitor) {
-    // 1. Stream cached URL file (if list has a URL and cache exists)
-    if (config.url.has_value() && cache_.has_cache(name)) {
+    // The cached URL file is used only while the list still declares a URL
+    // source; a stale cache for a removed URL is ignored here.
+    const bool include_cache = config.url.has_value() && cache_.has_cache(name);
+    stream_all_sources(name, config, visitor, include_cache);
+}
+
+void ListStreamer::stream_list_preferring_cache(const std::string& name,
+                                                const ListConfig& config,
+                                                ListEntryVisitor& visitor) {
+    // Use the cached file whenever it exists, even if the URL source was
+    // removed from the config. The local file and inline entries are always
+    // streamed too — they must not be dropped just because a cache exists.
+    stream_all_sources(name, config, visitor, cache_.has_cache(name));
+}
+
+void ListStreamer::stream_all_sources(const std::string& name,
+                                      const ListConfig& config,
+                                      ListEntryVisitor& visitor,
+                                      bool include_cache) {
+    // 1. Cached URL file
+    if (include_cache) {
         stream_file(cache_.cache_path(name), visitor);
     }
 
-    // 2. Stream local file (if configured)
+    // 2. Local file (if configured)
     if (config.file.has_value()) {
         stream_file(config.file.value(), visitor);
     }
 
-    // 3. Stream inline ip_cidrs via classify_entry()
+    // 3. Inline ip_cidrs via classify_entry()
     for (const auto& entry : config.ip_cidrs.value_or(std::vector<std::string>{})) {
         ListParser::classify_entry(entry, visitor);
     }
 
-    // 4. Stream inline domains as Domain entries
+    // 4. Inline domains as Domain entries
     for (const auto& domain : config.domains.value_or(std::vector<std::string>{})) {
         visitor.on_entry(EntryType::Domain, domain);
     }
 
     // Signal that all sources for this list have been processed
     visitor.on_list_complete(name);
-}
-
-void ListStreamer::stream_list_preferring_cache(const std::string& name,
-                                                const ListConfig& config,
-                                                ListEntryVisitor& visitor) {
-    if (cache_.has_cache(name)) {
-        stream_file(cache_.cache_path(name), visitor);
-        visitor.on_list_complete(name);
-        return;
-    }
-
-    stream_list(name, config, visitor);
 }
 
 void ListStreamer::stream_cache(const std::string& name, ListEntryVisitor& visitor) {

--- a/src/lists/list_streamer.hpp
+++ b/src/lists/list_streamer.hpp
@@ -16,8 +16,9 @@ public:
     // through the visitor. Calls visitor.on_list_complete(name) when done.
     void stream_list(const std::string& name, const ListConfig& config, ListEntryVisitor& visitor);
 
-    // Stream cached content only when present; otherwise fall back to all list
-    // sources. Calls visitor.on_list_complete(name) when done.
+    // Stream all sources for a named list, the same as stream_list(), but use
+    // the cached file whenever it exists — even if the list no longer declares
+    // a URL source. Calls visitor.on_list_complete(name) when done.
     void stream_list_preferring_cache(const std::string& name,
                                      const ListConfig& config,
                                      ListEntryVisitor& visitor);
@@ -26,6 +27,13 @@ public:
     void stream_cache(const std::string& name, ListEntryVisitor& visitor);
 
 private:
+    // Stream a list's local file and inline entries through the visitor,
+    // optionally preceded by the cached file. Calls on_list_complete(name).
+    void stream_all_sources(const std::string& name,
+                            const ListConfig& config,
+                            ListEntryVisitor& visitor,
+                            bool include_cache);
+
     // Open a file and stream its entries through the visitor.
     static void stream_file(const std::filesystem::path& path, ListEntryVisitor& visitor);
 

--- a/tests/test_dnsmasq_gen.cpp
+++ b/tests/test_dnsmasq_gen.cpp
@@ -1005,9 +1005,9 @@ TEST_CASE("generate-resolver-config ignores domains longer than 255 chars") {
     CHECK(output.find(invalid) == std::string::npos);
 }
 
-TEST_CASE("generate-resolver-config prefers cached list content over file and inline entries") {
+TEST_CASE("generate-resolver-config merges cached content with file and inline entries") {
     const auto temp_root =
-        std::filesystem::temp_directory_path() / "keen-pbr-test-dnsmasq-cache-preferred";
+        std::filesystem::temp_directory_path() / "keen-pbr-test-dnsmasq-cache-merged";
     std::filesystem::remove_all(temp_root);
     std::filesystem::create_directories(temp_root);
 
@@ -1046,9 +1046,11 @@ TEST_CASE("generate-resolver-config prefers cached list content over file and in
         DnsmasqGenerator gen(reg, streamer, route_cfg, dns_cfg, lists);
         const std::string output = run_generate(gen);
 
+        // The cached URL content is used in place of a re-download, but the
+        // list's local file and inline domains must never be dropped.
         CHECK(output.find("from-cache.example") != std::string::npos);
-        CHECK(output.find("from-file.example") == std::string::npos);
-        CHECK(output.find("from-inline.example") == std::string::npos);
+        CHECK(output.find("from-file.example") != std::string::npos);
+        CHECK(output.find("from-inline.example") != std::string::npos);
 
         cleanup();
     } catch (...) {


### PR DESCRIPTION
## Problem

`ListStreamer::stream_list_preferring_cache()` streamed the cached URL file and then returned early, skipping the list's local `file` source and inline `ip_cidrs` / `domains`. dnsmasq config generation uses this path, so a list that combined a (cached) URL source with inline domains silently lost those inline domains — they never reached dnsmasq and their traffic was not policy-routed.

## Fix

Extract the shared source-streaming logic into `stream_all_sources()`. Both `stream_list()` and `stream_list_preferring_cache()` now always stream the local file and inline entries; they differ only in when the cached file is used.

## Testing

Updates a `test_dnsmasq_gen` case to assert cached lists still emit file + inline entries. Full doctest suite passes.