### PR TITLE
fix(dns): serialize legacy resolver calls that share the global _res

### DIFF
--- a/src/cmd/test_routing.cpp
+++ b/src/cmd/test_routing.cpp
@@ -2,6 +2,7 @@
 
 #include "../config/routing_state.hpp"
 #include "../dns/dns_server.hpp"
+#include "../dns/legacy_resolver_lock.hpp"
 #include "../lists/ipset.hpp"
 #include "../lists/kernel_set_tester.hpp"
 #include "../lists/list_entry_visitor.hpp"
@@ -181,6 +182,8 @@ std::optional<std::string> query_dns_record_with_resolver(
     int response_len = -1;
 
     if (!server.has_value()) {
+        // res_query() resolves via the global _res; serialize it.
+        std::lock_guard<std::mutex> resolver_lock(legacy_resolver_mutex());
         response_len = res_query(domain.c_str(),
                                  ns_c_in,
                                  record_type,
@@ -212,15 +215,20 @@ std::optional<std::string> query_dns_record_with_resolver(
         }
 
         std::array<unsigned char, NS_PACKETSZ * 2> query {};
-        const int query_len = res_mkquery(ns_o_query,
-                                          domain.c_str(),
-                                          ns_c_in,
-                                          record_type,
-                                          nullptr,
-                                          0,
-                                          nullptr,
-                                          query.data(),
-                                          static_cast<int>(query.size()));
+        int query_len = -1;
+        {
+            // res_mkquery() builds the packet using the global _res.
+            std::lock_guard<std::mutex> resolver_lock(legacy_resolver_mutex());
+            query_len = res_mkquery(ns_o_query,
+                                    domain.c_str(),
+                                    ns_c_in,
+                                    record_type,
+                                    nullptr,
+                                    0,
+                                    nullptr,
+                                    query.data(),
+                                    static_cast<int>(query.size()));
+        }
         if (query_len < 0) {
             return keen_pbr3::format("Failed to build DNS {} query",
                                      record_type == ns_t_a ? "A" : "AAAA");

--- a/src/dns/dns_txt_client.cpp
+++ b/src/dns/dns_txt_client.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "dns_server.hpp"
+#include "legacy_resolver_lock.hpp"
 
 namespace keen_pbr3 {
 
@@ -198,15 +199,20 @@ std::optional<std::string> query_dns_txt_record(const std::string& dns_server_ad
     }
 
     std::array<unsigned char, NS_PACKETSZ * 2> query {};
-    const int query_len = res_mkquery(ns_o_query,
-                                      domain.c_str(),
-                                      ns_c_in,
-                                      ns_t_txt,
-                                      nullptr,
-                                      0,
-                                      nullptr,
-                                      query.data(),
-                                      static_cast<int>(query.size()));
+    int query_len = -1;
+    {
+        // res_mkquery() builds the packet using the global _res; serialize it.
+        std::lock_guard<std::mutex> resolver_lock(legacy_resolver_mutex());
+        query_len = res_mkquery(ns_o_query,
+                                domain.c_str(),
+                                ns_c_in,
+                                ns_t_txt,
+                                nullptr,
+                                0,
+                                nullptr,
+                                query.data(),
+                                static_cast<int>(query.size()));
+    }
     if (query_len < 0) {
         if (error_out) *error_out = "Failed to build DNS TXT query";
         Logger::instance().trace("dns_txt_query_error",

--- a/src/dns/legacy_resolver_lock.hpp
+++ b/src/dns/legacy_resolver_lock.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <mutex>
+
+namespace keen_pbr3 {
+
+// The legacy BIND resolver routines (res_query, res_mkquery, ...) operate on
+// the process-global `_res` state and are not thread-safe. keen-pbr issues
+// such queries from several threads — resolver health probes on the blocking
+// executor and test-routing requests on API worker threads — so every call
+// that touches `_res` must be serialized on this shared mutex.
+//
+// The res_n* (per-state) variants would avoid the lock, but they are absent
+// on some target C libraries (musl). A shared mutex is portable, and the
+// affected queries are infrequent diagnostics where serialization is harmless.
+inline std::mutex& legacy_resolver_mutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+} // namespace keen_pbr3


### PR DESCRIPTION
## Problem

`res_query()` and `res_mkquery()` operate on the process-global `_res` resolver state and are not thread-safe. keen-pbr calls them from resolver health probes (on the blocking executor) and from test-routing requests (on API worker threads), so concurrent queries race on `_res`.

## Fix

Add a shared `legacy_resolver_mutex()` and hold it around every `res_query()` / `res_mkquery()` call.

The `res_n*` per-state variants would avoid the lock, but they are absent on musl (used by OpenWrt and some Keenetic toolchains); a shared mutex is portable and these queries are infrequent diagnostics where serialization is harmless.

## Testing

Full doctest suite passes.