### PR TITLE
feat(frontend): bulk select and act on table rows

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Use bun only — npm/yarn/pnpm lockfiles are not tracked
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/src/api/mutations.ts
+++ b/frontend/src/api/mutations.ts
@@ -127,8 +127,26 @@ export const usePostServiceActionMutation = (action: ServiceAction) => {
   })
 }
 
+/** Pure helper for tests and non-hook callers. */
+export function isConfigMutationPending(
+  postConfigCount: number,
+  postConfigSaveCount: number,
+): boolean {
+  return postConfigCount > 0 || postConfigSaveCount > 0
+}
+
+/** True while `/api/config` draft save or `/api/config/save` apply is in-flight (globally). */
+export const useConfigMutationPending = () => {
+  const postDraftMutations = useIsMutating({ mutationKey: ["postConfig"] })
+  const applyMutations = useIsMutating({ mutationKey: ["postConfigSave"] })
+
+  return isConfigMutationPending(postDraftMutations, applyMutations)
+}
+
 export const useRoutingControlPendingState = () => {
+  const draftPostPending = useIsMutating({ mutationKey: ["postConfig"] }) > 0
   const applyPending = useIsMutating({ mutationKey: ["postConfigSave"] }) > 0
+  const configMutationPending = draftPostPending || applyPending
   const startPending =
     useIsMutating({ mutationKey: serviceActionMutationKey("start") }) > 0
   const stopPending =
@@ -138,9 +156,15 @@ export const useRoutingControlPendingState = () => {
 
   return {
     applyPending,
+    draftPostPending,
+    configMutationPending,
     startPending,
     stopPending,
     restartPending,
-    anyPending: applyPending || startPending || stopPending || restartPending,
+    anyPending:
+      configMutationPending ||
+      startPending ||
+      stopPending ||
+      restartPending,
   }
 }

--- a/frontend/src/components/shared/bulk-selection-toolbar.tsx
+++ b/frontend/src/components/shared/bulk-selection-toolbar.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react"
+
+export function BulkSelectionToolbar({
+  countLabel,
+  children,
+}: {
+  countLabel: string
+  children: ReactNode
+}) {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2 rounded-lg border bg-muted/20 px-3 py-2"
+      data-testid="bulk-selection-toolbar"
+    >
+      <span
+        aria-atomic="true"
+        aria-live="polite"
+        className="text-sm font-medium tabular-nums"
+        data-testid="bulk-selection-count"
+      >
+        {countLabel}
+      </span>
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/components/shared/config-save-error-alert.tsx
+++ b/frontend/src/components/shared/config-save-error-alert.tsx
@@ -1,0 +1,17 @@
+import type { ApiError } from "@/api/client"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { getApiErrorMessage } from "@/lib/api-errors"
+
+/** Inline alert when staged config save fails (complements toast feedback). */
+export function ConfigSaveErrorAlert({ error }: { error: unknown }) {
+  const message = getApiErrorMessage(error as ApiError | null)
+  if (!message) {
+    return null
+  }
+
+  return (
+    <Alert className="border-destructive/30 bg-destructive/5 text-destructive">
+      <AlertDescription className="whitespace-pre-wrap">{message}</AlertDescription>
+    </Alert>
+  )
+}

--- a/frontend/src/components/shared/data-table.tsx
+++ b/frontend/src/components/shared/data-table.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react"
 
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Table,
   TableBody,
@@ -9,76 +10,157 @@ import {
   TableRow,
 } from "@/components/ui/table"
 
+export type DataTableSelection = {
+  rowIds: string[]
+  selectedIds: ReadonlySet<string>
+  onToggleRow: (rowId: string) => void
+  onSelectAllVisible: (selected: boolean) => void
+  /** Shown beside the header “select all” control (native title / concise hint). */
+  selectAllTooltip?: string
+  selectAllAriaLabel: string
+  selectRowAriaLabel: (rowId: string) => string
+  /** Disables checkbox column (e.g. while a mutation is pending). */
+  selectionDisabled?: boolean
+}
+
 export function DataTable({
   headers,
   rows,
   compact = false,
   narrowColumns = [],
+  selection,
 }: {
   headers?: string[]
   rows: ReactNode[][]
   compact?: boolean
   narrowColumns?: number[]
+  selection?: DataTableSelection
 }) {
-  const lastColumnIndex = headers ? headers.length - 1 : (
-    (rows.length && rows[0]?.length) ? rows[0].length - 1 : 0
+  const hasSelection =
+    Boolean(selection && selection.rowIds.length === rows.length)
+  const mergedHeaders =
+    hasSelection && headers ? ["", ...headers] : headers
+  const lastColumnIndex = mergedHeaders
+    ? mergedHeaders.length - 1
+    : (rows.length && rows[0]?.length)
+      ? rows[0].length - 1
+      : 0
+  // Callers pass narrowColumns in content-column coordinates; when a selection
+  // checkbox column is prepended, shift them so the styling stays aligned.
+  const narrowColumnSet = new Set(
+    hasSelection ? narrowColumns.map((index) => index + 1) : narrowColumns,
   )
-  const narrowColumnSet = new Set(narrowColumns)
+
+  const visibleIds =
+    hasSelection ? selection!.rowIds.filter((id) => id.length > 0) : []
+  const allSelectableSelected =
+    visibleIds.length > 0 &&
+    visibleIds.every((id) => selection!.selectedIds.has(id))
+
+  function headClass(headerIndex: number) {
+    return headerIndex === lastColumnIndex
+      ? compact
+        ? "h-8 w-px text-right font-semibold"
+        : "w-px text-right font-semibold"
+      : narrowColumnSet.has(headerIndex)
+        ? compact
+          ? "h-8 w-px font-semibold whitespace-nowrap"
+          : "w-px font-semibold whitespace-nowrap"
+        : compact
+          ? "h-8 font-semibold"
+          : "font-semibold"
+  }
+
+  function cellClass(cellIndex: number) {
+    return cellIndex === lastColumnIndex
+      ? compact
+        ? "w-px px-2 py-1.5 text-right align-middle whitespace-nowrap"
+        : "w-px p-3 text-right align-middle whitespace-nowrap"
+      : narrowColumnSet.has(cellIndex)
+        ? compact
+          ? "w-px px-2 py-1.5 align-middle whitespace-nowrap"
+          : "w-px p-3 align-middle whitespace-nowrap"
+        : compact
+          ? "px-2 py-1.5 align-middle whitespace-normal"
+          : "p-3 align-middle whitespace-normal"
+  }
+
+  const selectionLocked = Boolean(selection?.selectionDisabled)
 
   return (
-    <div className="max-w-full overflow-x-auto rounded-md border">
+    <div
+      aria-busy={selectionLocked}
+      className="max-w-full overflow-x-auto rounded-md border"
+    >
       <Table className={compact ? "w-full text-sm" : "w-full text-base"}>
-        {headers && (
+        {mergedHeaders ? (
           <TableHeader className="bg-muted/50">
             <TableRow>
-              {headers.map((header, headerIndex) => (
-                <TableHead
-                  className={
-                    headerIndex === lastColumnIndex
-                      ? compact
-                        ? "h-8 w-px text-right font-semibold"
-                        : "w-px text-right font-semibold"
-                      : narrowColumnSet.has(headerIndex)
-                        ? compact
-                          ? "h-8 w-px font-semibold whitespace-nowrap"
-                          : "w-px font-semibold whitespace-nowrap"
-                        : compact
-                          ? "h-8 font-semibold"
-                          : "font-semibold"
-                  }
-                  key={header}
-                >
-                  {header}
+              {mergedHeaders.map((header, headerIndex) => (
+                <TableHead className={headClass(headerIndex)} key={`h-${headerIndex}`}>
+                  {hasSelection && headerIndex === 0 ? (
+                    <div className="flex justify-center pt-1" title={selection!.selectAllTooltip}>
+                      <Checkbox
+                        aria-label={selection!.selectAllAriaLabel}
+                        checked={allSelectableSelected}
+                        disabled={selectionLocked || visibleIds.length === 0}
+                        onCheckedChange={(checked) => {
+                          selection!.onSelectAllVisible(checked === true)
+                        }}
+                      />
+                    </div>
+                  ) : (
+                    header
+                  )}
                 </TableHead>
               ))}
             </TableRow>
           </TableHeader>
-        )}
+        ) : null}
         <TableBody>
-          {rows.map((row, index) => (
-            <TableRow key={`${row[0]}-${index}`}>
-              {row.map((cell, cellIndex) => (
-                <TableCell
-                  className={
-                    cellIndex === lastColumnIndex
-                      ? compact
-                        ? "w-px px-2 py-1.5 text-right align-middle whitespace-nowrap"
-                        : "w-px p-3 text-right align-middle whitespace-nowrap"
-                      : narrowColumnSet.has(cellIndex)
-                        ? compact
-                          ? "w-px px-2 py-1.5 align-middle whitespace-nowrap"
-                          : "w-px p-3 align-middle whitespace-nowrap"
-                        : compact
-                          ? "px-2 py-1.5 align-middle whitespace-normal"
-                          : "p-3 align-middle whitespace-normal"
-                  }
-                  key={cellIndex}
-                >
-                  {cell}
-                </TableCell>
-              ))}
-            </TableRow>
-          ))}
+          {rows.map((row, index) => {
+            const rowId = hasSelection ? selection!.rowIds[index] ?? "" : ""
+
+            const cells = (
+              <>
+                {hasSelection ? (
+                  <TableCell className={cellClass(0)} key="selection">
+                    <div className="flex justify-center">
+                      <Checkbox
+                        aria-label={
+                          rowId
+                            ? selection!.selectRowAriaLabel(rowId)
+                            : selection!.selectAllAriaLabel
+                        }
+                        checked={rowId ? selection!.selectedIds.has(rowId) : false}
+                        disabled={selectionLocked || !rowId}
+                        onCheckedChange={() => {
+                          if (rowId) {
+                            selection!.onToggleRow(rowId)
+                          }
+                        }}
+                      />
+                    </div>
+                  </TableCell>
+                ) : null}
+                {row.map((cell, cellIndex) => {
+                  const displayIndex =
+                    cellIndex + (hasSelection ? 1 : 0)
+                  return (
+                    <TableCell className={cellClass(displayIndex)} key={cellIndex}>
+                      {cell}
+                    </TableCell>
+                  )
+                })}
+              </>
+            )
+
+            return (
+              <TableRow key={hasSelection ? rowId || `${index}` : `${row[0]}-${index}`}>
+                {cells}
+              </TableRow>
+            )
+          })}
         </TableBody>
       </Table>
     </div>

--- a/frontend/src/components/shared/list-placeholder.tsx
+++ b/frontend/src/components/shared/list-placeholder.tsx
@@ -20,7 +20,10 @@ export function ListPlaceholder({
   const Icon = variant === "error" ? TriangleAlert : Inbox
 
   return (
-    <Empty className="border">
+    <Empty
+      className="min-h-[14rem] justify-center border sm:min-h-0"
+      data-testid={`list-placeholder-${variant}`}
+    >
       <EmptyHeader>
         <EmptyMedia variant="icon">
           <Icon />

--- a/frontend/src/components/shared/upsert-page.tsx
+++ b/frontend/src/components/shared/upsert-page.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react"
 
 import { PageHeader } from "@/components/shared/page-header"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { useIsMobile } from "@/hooks/use-mobile"
 
 export function UpsertPage({
   title,
@@ -16,10 +17,12 @@ export function UpsertPage({
   cardDescription: string
   children: ReactNode
 }) {
+  const isMobile = useIsMobile()
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-5 md:space-y-6">
       <PageHeader description={description} title={title} />
-      <Card>
+      <Card size={isMobile ? "sm" : "default"}>
         <CardHeader>
           <CardTitle>{cardTitle}</CardTitle>
           <CardDescription>{cardDescription}</CardDescription>

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -34,6 +34,10 @@ export const enTranslation = {
         validation: {
           tagNamePattern: "Can only contain a-z, 0-9 and underscores. Max 24 characters, must start with a letter.",
         },
+        selection: {
+          selectAll: "Select all visible rows",
+          selectRow: "Select {{rowLabel}}",
+        },
       },
       runtime: {
         healthy: "Healthy",
@@ -393,6 +397,12 @@ export const enTranslation = {
               'DNS server "{{serverTag}}" is currently used by {{count}} rule(s){{fallbackSuffix}}.\nDelete and automatically remove those references?',
             fallbackSuffix: " and as fallback",
           },
+          bulk: {
+            selected: "{{count}} selected",
+            delete: "Delete selected",
+            confirmDelete:
+              "Delete DNS servers {{tags}}?\nAutomatically remove stale references?",
+          },
           none: "none",
         },
         dnsServerUpsert: {
@@ -458,6 +468,14 @@ export const enTranslation = {
             addRule: "Add routing rule",
             enableRule: "Enable rule",
             disableRule: "Disable rule",
+          },
+          bulk: {
+            selected: "{{count}} selected",
+            enable: "Enable selected",
+            disable: "Disable selected",
+            delete: "Delete selected",
+            confirmDelete:
+              "Delete {{count}} routing rule(s)? This cannot be undone from this screen alone.",
           },
           messages: {
             saved: "Routing rules staged. Apply new config to persist them.",
@@ -543,6 +561,11 @@ export const enTranslation = {
         },
         outbounds: {
           title: "Outbounds",
+          bulk: {
+            selected: "{{count}} selected",
+            delete: "Delete selected",
+            confirmDelete: "Delete {{count}} outbound(s)? Dependencies are not validated until save.",
+          },
           description: "Your configured outbounds and urltest groups.",
           actions: { new: "Add outbound" },
           empty: {
@@ -734,6 +757,13 @@ export const enTranslation = {
             enabled: "Allowed",
             disabled: "Blocked",
           },
+          bulk: {
+            selected: "{{count}} selected",
+            enable: "Enable selected",
+            disable: "Disable selected",
+            delete: "Delete selected",
+            confirmDelete: "Delete {{count}} DNS rule(s)?",
+          },
         },
         dnsRuleUpsert: {
           createTitle: "Create DNS rule",
@@ -793,6 +823,15 @@ export const enTranslation = {
             stats: "Entries",
             rules: "Used in rules",
             actions: "Actions",
+          },
+          bulk: {
+            selected: "{{count}} selected",
+            refreshSelected: "Update selected (URL)",
+            deleteSelected: "Delete selected lists",
+            confirmDeleteSimple: 'Delete lists: {{names}}?',
+            confirmDeleteWithRefs:
+              "Delete lists: {{names}} and remove references from routing/DNS rules where needed?",
+            noUrlBacked: "None of the selected lists are URL-backed.",
           },
           delete: {
             confirm: 'Delete list "{{name}}"?',

--- a/frontend/src/i18n/ru.ts
+++ b/frontend/src/i18n/ru.ts
@@ -35,6 +35,10 @@ export const ruTranslation = {
         validation: {
           tagNamePattern: "Может содержать только a-z, 0-9 и подчёркивание. Максимум 24 символа, должен начинаться с буквы.",
         },
+        selection: {
+          selectAll: "Выбрать все видимые строки",
+          selectRow: "Выбрать {{rowLabel}}",
+        },
       },
       runtime: {
         healthy: "Исправен",
@@ -402,6 +406,12 @@ export const ruTranslation = {
               'DNS-сервер "{{serverTag}}" сейчас используется в {{count}} правил(е/ах){{fallbackSuffix}}.\nУдалить и автоматически убрать эти ссылки?',
             fallbackSuffix: " и как fallback",
           },
+          bulk: {
+            selected: "Выбрано: {{count}}",
+            delete: "Удалить выбранные",
+            confirmDelete:
+              "Удалить DNS-серверы: {{tags}}?\nАвтоматически убрать ссылки из правил?",
+          },
           none: "нет",
         },
         dnsServerUpsert: {
@@ -466,6 +476,14 @@ export const ruTranslation = {
             addRule: "Добавить правило маршрутизации",
             enableRule: "Включить правило",
             disableRule: "Выключить правило",
+          },
+          bulk: {
+            selected: "Выбрано: {{count}}",
+            enable: "Включить выбранные",
+            disable: "Выключить выбранные",
+            delete: "Удалить выбранные",
+            confirmDelete:
+              "Удалить {{count}} правил(о/а) маршрутизации? Изменение нельзя отменить здесь одним действием.",
           },
           messages: {
             saved:
@@ -554,6 +572,12 @@ export const ruTranslation = {
         },
         outbounds: {
           title: "Outbounds (выходы)",
+          bulk: {
+            selected: "Выбрано: {{count}}",
+            delete: "Удалить выбранные",
+            confirmDelete:
+              "Удалить {{count}} outbound(ов)? Связи проверяются только при сохранении.",
+          },
           description: "Настроенные outbounds и группы urltest.",
           actions: { new: "Добавить outbound" },
           empty: {
@@ -752,6 +776,13 @@ export const ruTranslation = {
             enabled: "Разрешён",
             disabled: "Запрещён",
           },
+          bulk: {
+            selected: "Выбрано: {{count}}",
+            enable: "Включить выбранные",
+            disable: "Выключить выбранные",
+            delete: "Удалить выбранные",
+            confirmDelete: "Удалить {{count}} DNS-правил(о/а)?",
+          },
         },
         dnsRuleUpsert: {
           createTitle: "Создать DNS-правило",
@@ -814,6 +845,16 @@ export const ruTranslation = {
             stats: "Записи",
             rules: "Исп. в правилах",
             actions: "Действия",
+          },
+          bulk: {
+            selected: "Выбрано: {{count}}",
+            refreshSelected: "Обновить выбранные (URL)",
+            deleteSelected: "Удалить выбранные списки",
+            confirmDeleteSimple: "Удалить списки: {{names}}?",
+            confirmDeleteWithRefs:
+              "Удалить списки: {{names}} и при необходимости убрать ссылки из правил маршрутизации и DNS?",
+            noUrlBacked:
+              "Ни один из выбранных списков не основан на URL (обновление нечего).",
           },
           delete: {
             confirm: 'Удалить список "{{name}}"?',

--- a/frontend/src/pages/dns-rules-page.tsx
+++ b/frontend/src/pages/dns-rules-page.tsx
@@ -1,5 +1,5 @@
 import { Pencil, Plus, Trash2 } from "lucide-react"
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 
@@ -7,12 +7,14 @@ import { useQueryClient } from "@tanstack/react-query"
 import { useLocation } from "wouter"
 
 import type { ApiError } from "@/api/client"
-import { usePostConfigMutation } from "@/api/mutations"
+import { usePostConfigMutation, useConfigMutationPending } from "@/api/mutations"
 import { queryKeys } from "@/api/query-keys"
 import { useGetConfig } from "@/api/queries"
 import { selectConfig } from "@/api/selectors"
 import { ActionButtons } from "@/components/shared/action-buttons"
-import { DataTable } from "@/components/shared/data-table"
+import { BulkSelectionToolbar } from "@/components/shared/bulk-selection-toolbar"
+import { ConfigSaveErrorAlert } from "@/components/shared/config-save-error-alert"
+import { DataTable, type DataTableSelection } from "@/components/shared/data-table"
 import {
   Field,
   FieldContent,
@@ -40,6 +42,7 @@ export function DnsRulesPage() {
   const queryClient = useQueryClient()
   const [, navigate] = useLocation()
   const configQuery = useGetConfig()
+  const configMutationPending = useConfigMutationPending()
 
   const loadedConfig = selectConfig(configQuery.data)
 
@@ -69,7 +72,30 @@ export function DnsRulesPage() {
     },
   })
 
-  const rules = loadedConfig?.dns?.rules ?? []
+  const rules = useMemo(
+    () => loadedConfig?.dns?.rules ?? [],
+    [loadedConfig?.dns?.rules],
+  )
+
+  const [selectedDnsRuleIndices, setSelectedDnsRuleIndices] = useState<
+    Set<string>
+  >(() => new Set())
+
+  const validDnsRuleIndexSet = useMemo(
+    () => new Set(rules.map((_rule, ruleIndex: number) => String(ruleIndex))),
+    [rules],
+  )
+
+  const selectedDnsRuleIndicesResolved = useMemo(() => {
+    const next = new Set<string>()
+    for (const id of selectedDnsRuleIndices) {
+      if (validDnsRuleIndexSet.has(id)) {
+        next.add(id)
+      }
+    }
+
+    return next
+  }, [selectedDnsRuleIndices, validDnsRuleIndexSet])
 
   const handleFallbackChange = (fallback: string[]) => {
     if (!loadedConfig) {
@@ -151,11 +177,110 @@ export function DnsRulesPage() {
     })
   }
 
+  const handleBulkDeleteRules = () => {
+    if (!loadedConfig || selectedDnsRuleIndicesResolved.size === 0) {
+      return
+    }
+
+    const confirmed = window.confirm(
+      t("pages.dnsRules.bulk.confirmDelete", {
+        count: selectedDnsRuleIndicesResolved.size,
+      }),
+    )
+
+    if (!confirmed) {
+      return
+    }
+
+    const nextDraftRules = rules
+      .filter((_rule, ruleIndex) => !selectedDnsRuleIndicesResolved.has(String(ruleIndex)))
+      .map((rule) => getRuleDraft(rule))
+
+    const validation = validateRules(nextDraftRules, serverTags, listOptions)
+    if (Object.keys(validation).length > 0) {
+      toast.error(t("pages.dnsRules.validation.invalidResult"), {
+        richColors: true,
+      })
+      return
+    }
+
+    postConfigMutation.mutate(
+      {
+        data: buildUpdatedConfigWithRules(
+          loadedConfig,
+          loadedConfig.dns?.fallback ?? [],
+          nextDraftRules,
+        ),
+      },
+      {
+        onSuccess: () => {
+          setSelectedDnsRuleIndices(new Set())
+        },
+      },
+    )
+  }
+
+  const handleBulkSetDnsRulesEnabled = (enabled: boolean) => {
+    if (!loadedConfig || selectedDnsRuleIndicesResolved.size === 0) {
+      return
+    }
+
+    let nextDraftRules = rules.map((rule) => getRuleDraft(rule))
+    for (const sid of selectedDnsRuleIndicesResolved) {
+      nextDraftRules = setDnsRuleEnabled(nextDraftRules, Number(sid), enabled)
+    }
+
+    const validation = validateRules(nextDraftRules, serverTags, listOptions)
+    if (Object.keys(validation).length > 0) {
+      toast.error(t("pages.dnsRules.validation.invalidResult"), {
+        richColors: true,
+      })
+      return
+    }
+
+    postConfigMutation.mutate({
+      data: buildUpdatedConfigWithRules(
+        loadedConfig,
+        loadedConfig.dns?.fallback ?? [],
+        nextDraftRules,
+      ),
+    })
+  }
+
+  const dnsRulesSelectionProps: DataTableSelection = {
+    rowIds: rules.map((_rule, ruleIndex: number) => String(ruleIndex)),
+    selectedIds: selectedDnsRuleIndicesResolved,
+    selectionDisabled: configMutationPending,
+    selectAllAriaLabel: t("common.selection.selectAll"),
+    selectRowAriaLabel: (rowId: string) =>
+      t("common.selection.selectRow", {
+        rowLabel: `${t("pages.dnsRules.title")} #${Number(rowId) + 1}`,
+      }),
+    selectAllTooltip: t("common.selection.selectAll"),
+    onToggleRow: (rowId: string) => {
+      setSelectedDnsRuleIndices((previous) => {
+        const next = new Set(previous)
+        if (next.has(rowId)) {
+          next.delete(rowId)
+        } else {
+          next.add(rowId)
+        }
+
+        return next
+      })
+    },
+    onSelectAllVisible: (selectedAll: boolean) => {
+      setSelectedDnsRuleIndices(
+        selectedAll ? new Set(rules.map((_r, idx) => String(idx))) : new Set(),
+      )
+    },
+  }
+
   return (
     <div className="space-y-6">
       <PageHeader
         actions={
-          <Button onClick={() => navigate("/dns-rules/create")}>
+          <Button disabled={configMutationPending} onClick={() => navigate("/dns-rules/create")}>
             <Plus className="mr-1 h-4 w-4" />
             {t("pages.dnsRules.actions.add")}
           </Button>
@@ -163,6 +288,8 @@ export function DnsRulesPage() {
         description={t("pages.dnsRules.description")}
         title={t("pages.dnsRules.title")}
       />
+
+      <ConfigSaveErrorAlert error={postConfigMutation.error} />
 
       {configQuery.isLoading ? (
         <TableSkeleton />
@@ -174,7 +301,7 @@ export function DnsRulesPage() {
         />
       ) : (
         <>
-          <Card>
+          <Card inert={configMutationPending ? true : undefined}>
             <CardContent>
               <Field>
                 <FieldLabel>{t("pages.dnsRules.fallback.title")}</FieldLabel>
@@ -214,68 +341,114 @@ export function DnsRulesPage() {
               title={t("pages.dnsRules.empty.title")}
             />
           ) : (
-            <DataTable
-              headers={[
-                "",
-                t("pages.dnsRules.headers.criteria"),
-                t("pages.dnsRules.headers.serverTag"),
-                t("pages.dnsRules.headers.allowDomainRebinding"),
-                t("pages.dnsRules.headers.actions"),
-              ]}
-              narrowColumns={[0]}
-              rows={rules.map((rule, index) => [
-                <div className="flex items-center" key={`enabled-${index}`}>
-                  <Switch
-                    aria-label={t(
-                      (rule.enabled ?? true)
-                        ? "pages.dnsRules.actions.disableRule"
-                        : "pages.dnsRules.actions.enableRule"
-                    )}
-                    checked={rule.enabled ?? true}
-                    onCheckedChange={(checked) => handleEnabledChange(index, checked)}
-                    title={t(
-                      (rule.enabled ?? true)
-                        ? "pages.dnsRules.actions.disableRule"
-                        : "pages.dnsRules.actions.enableRule"
-                    )}
-                  />
-                </div>,
-                <ul className="list-disc space-y-1 pl-5 text-sm" key={`criteria-${index}`}>
-                  <li className="text-muted-foreground">
-                    <span className="font-medium text-foreground">
-                      {t("pages.dnsRules.criteriaLabels.lists")}:
-                    </span>{" "}
-                    {rule.list.join(", ")}
-                  </li>
-                </ul>,
-                <span className="font-medium" key={`server-${index}`}>
-                  {rule.server}
-                </span>,
-                <Badge
-                  key={`allow-domain-rebinding-${index}`}
-                  variant={rule.allow_domain_rebinding ? "default" : "outline"}
+            <div className="space-y-3">
+              {selectedDnsRuleIndicesResolved.size > 0 ? (
+                <BulkSelectionToolbar
+                  countLabel={t("pages.dnsRules.bulk.selected", {
+                    count: selectedDnsRuleIndicesResolved.size,
+                  })}
                 >
-                  {rule.allow_domain_rebinding
-                    ? t("pages.dnsRules.rebinding.enabled")
-                    : t("pages.dnsRules.rebinding.disabled")}
-                </Badge>,
-                <ActionButtons
-                  actions={[
-                    {
-                      icon: <Pencil className="h-4 w-4" />,
-                      label: t("common.edit"),
-                      onClick: () => navigate(`/dns-rules/${index}/edit`),
-                    },
-                    {
-                      icon: <Trash2 className="h-4 w-4" />,
-                      label: t("common.delete"),
-                      onClick: () => handleDeleteRule(index),
-                    },
-                  ]}
-                  key={`actions-${index}`}
-                />,
-              ])}
-            />
+                  <Button
+                    disabled={configMutationPending}
+                    onClick={() => handleBulkSetDnsRulesEnabled(true)}
+                    size="sm"
+                    variant="outline"
+                  >
+                    {t("pages.dnsRules.bulk.enable")}
+                  </Button>
+                  <Button
+                    disabled={configMutationPending}
+                    onClick={() => handleBulkSetDnsRulesEnabled(false)}
+                    size="sm"
+                    variant="outline"
+                  >
+                    {t("pages.dnsRules.bulk.disable")}
+                  </Button>
+                  <Button
+                    disabled={configMutationPending}
+                    onClick={() => handleBulkDeleteRules()}
+                    size="sm"
+                    variant="destructive"
+                  >
+                    <Trash2 className="mr-1 h-4 w-4" />
+                    {t("pages.dnsRules.bulk.delete")}
+                  </Button>
+                </BulkSelectionToolbar>
+              ) : null}
+              <DataTable
+                headers={[
+                  "",
+                  t("pages.dnsRules.headers.criteria"),
+                  t("pages.dnsRules.headers.serverTag"),
+                  t("pages.dnsRules.headers.allowDomainRebinding"),
+                  t("pages.dnsRules.headers.actions"),
+                ]}
+                narrowColumns={[0, 1]}
+                rows={rules.map((rule, index) => [
+                  <div className="flex items-center" key={`enabled-${index}`}>
+                    <Switch
+                      aria-label={t(
+                        (rule.enabled ?? true)
+                          ? "pages.dnsRules.actions.disableRule"
+                          : "pages.dnsRules.actions.enableRule"
+                      )}
+                      checked={rule.enabled ?? true}
+                      disabled={configMutationPending}
+                      onCheckedChange={(checked) =>
+                        handleEnabledChange(index, checked)
+                      }
+                      title={t(
+                        (rule.enabled ?? true)
+                          ? "pages.dnsRules.actions.disableRule"
+                          : "pages.dnsRules.actions.enableRule"
+                      )}
+                    />
+                  </div>,
+                  <ul
+                    className="list-disc space-y-1 pl-5 text-sm"
+                    key={`criteria-${index}`}
+                  >
+                    <li className="text-muted-foreground">
+                      <span className="font-medium text-foreground">
+                        {t("pages.dnsRules.criteriaLabels.lists")}:
+                      </span>{" "}
+                      {rule.list.join(", ")}
+                    </li>
+                  </ul>,
+                  <span className="font-medium" key={`server-${index}`}>
+                    {rule.server}
+                  </span>,
+                  <Badge
+                    key={`allow-domain-rebinding-${index}`}
+                    variant={
+                      rule.allow_domain_rebinding ? "default" : "outline"
+                    }
+                  >
+                    {rule.allow_domain_rebinding
+                      ? t("pages.dnsRules.rebinding.enabled")
+                      : t("pages.dnsRules.rebinding.disabled")}
+                  </Badge>,
+                  <ActionButtons
+                    actions={[
+                      {
+                        disabled: configMutationPending,
+                        icon: <Pencil className="h-4 w-4" />,
+                        label: t("common.edit"),
+                        onClick: () => navigate(`/dns-rules/${index}/edit`),
+                      },
+                      {
+                        disabled: configMutationPending,
+                        icon: <Trash2 className="h-4 w-4" />,
+                        label: t("common.delete"),
+                        onClick: () => handleDeleteRule(index),
+                      },
+                    ]}
+                    key={`actions-${index}`}
+                  />,
+                ])}
+                selection={dnsRulesSelectionProps}
+              />
+            </div>
           )}
         </>
       )}

--- a/frontend/src/pages/dns-servers-page.tsx
+++ b/frontend/src/pages/dns-servers-page.tsx
@@ -1,36 +1,135 @@
 import { Pencil, Plus, Trash2 } from "lucide-react"
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useLocation } from "wouter"
 
-import type { ApiError } from "@/api/client"
 import type { getConfigResponse } from "@/api/generated/keen-api"
 import type { ConfigObject } from "@/api/generated/model/configObject"
 import { DnsServerType } from "@/api/generated/model/dnsServerType"
-import { usePostConfigMutation } from "@/api/mutations"
+import { usePostConfigMutation, useConfigMutationPending } from "@/api/mutations"
 import { useGetConfig } from "@/api/queries"
 import { ActionButtons } from "@/components/shared/action-buttons"
-import { DataTable } from "@/components/shared/data-table"
+import { BulkSelectionToolbar } from "@/components/shared/bulk-selection-toolbar"
+import { ConfigSaveErrorAlert } from "@/components/shared/config-save-error-alert"
+import { DataTable, type DataTableSelection } from "@/components/shared/data-table"
 import { ListPlaceholder } from "@/components/shared/list-placeholder"
 import { PageHeader } from "@/components/shared/page-header"
 import { TableSkeleton } from "@/components/shared/table-skeleton"
-import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { getApiErrorMessage } from "@/lib/api-errors"
 
 export function DnsServersPage() {
   const { t } = useTranslation()
   const [, navigate] = useLocation()
+  const configMutationPending = useConfigMutationPending()
   const configQuery = useGetConfig()
   const postConfigMutation = usePostConfigMutation()
 
   const config = getConfigData(configQuery.data)
   const dnsServers = useMemo(() => config?.dns?.servers ?? [], [config])
 
-  const mutationErrorMessage = getApiErrorMessage(
-    postConfigMutation.error as ApiError | null
+  const rowIdsRaw = dnsServers.map((server) => server.tag)
+
+  const [selectedDnsServerTags, setSelectedDnsServerTags] = useState<Set<string>>(
+    () => new Set(),
   )
+
+  const validDnsServerTagSet = useMemo(
+    () => new Set(dnsServers.map((server) => server.tag)),
+    [dnsServers],
+  )
+
+  const selectedDnsServerTagsResolved = useMemo(() => {
+    const next = new Set<string>()
+    for (const tag of selectedDnsServerTags) {
+      if (validDnsServerTagSet.has(tag)) {
+        next.add(tag)
+      }
+    }
+
+    return next
+  }, [selectedDnsServerTags, validDnsServerTagSet])
+
+  const dnsServerSelectionProps: DataTableSelection = {
+    rowIds: rowIdsRaw,
+    selectedIds: selectedDnsServerTagsResolved,
+    selectionDisabled: configMutationPending,
+    selectAllAriaLabel: t("common.selection.selectAll"),
+    selectRowAriaLabel: (rowTag: string) =>
+      t("common.selection.selectRow", { rowLabel: rowTag }),
+    selectAllTooltip: t("common.selection.selectAll"),
+    onToggleRow: (tag: string) => {
+      setSelectedDnsServerTags((previous) => {
+        const next = new Set(previous)
+        if (next.has(tag)) {
+          next.delete(tag)
+        } else {
+          next.add(tag)
+        }
+
+        return next
+      })
+    },
+    onSelectAllVisible: (selectedAll: boolean) => {
+      setSelectedDnsServerTags(
+        selectedAll ? new Set(rowIdsRaw) : new Set(),
+      )
+    },
+  }
+
+  const deleteServersBulk = () => {
+    if (!config || selectedDnsServerTagsResolved.size === 0) {
+      return
+    }
+
+    const dnsConfig = config.dns
+    const allRules = dnsConfig?.rules ?? []
+    const fallbackServers = dnsConfig?.fallback ?? []
+    const selectedTagsArray = [...selectedDnsServerTagsResolved]
+    const tagSet = new Set(selectedDnsServerTagsResolved)
+
+    const matchingRulesCount = allRules.filter((rule) =>
+      selectedTagsArray.includes(rule.server),
+    ).length
+    const usesFallback = fallbackServers.some((tag) => tagSet.has(tag))
+
+    let stripReferencesFromConfig = !(matchingRulesCount > 0 || usesFallback)
+
+    if (matchingRulesCount > 0 || usesFallback) {
+      stripReferencesFromConfig = window.confirm(
+        t("pages.dnsServers.bulk.confirmDelete", {
+          tags: selectedTagsArray.join(", "),
+        }),
+      )
+
+      if (!stripReferencesFromConfig) {
+        return
+      }
+    }
+
+    const updatedConfig = {
+      ...config,
+      dns: {
+        ...(dnsConfig ?? {}),
+        servers: dnsServers.filter((server) => !tagSet.has(server.tag)),
+        rules: stripReferencesFromConfig
+          ? allRules.filter((rule) => !tagSet.has(rule.server))
+          : allRules,
+        fallback: stripReferencesFromConfig
+          ? fallbackServers.filter((tag) => !tagSet.has(tag))
+          : fallbackServers,
+      },
+    } satisfies ConfigObject
+
+    postConfigMutation.mutate(
+      { data: updatedConfig },
+      {
+        onSuccess: () => {
+          setSelectedDnsServerTags(new Set())
+        },
+      },
+    )
+  }
 
   const deleteServer = (serverTag: string) => {
     if (!config) {
@@ -86,7 +185,7 @@ export function DnsServersPage() {
     <div className="space-y-6">
       <PageHeader
         actions={
-          <Button onClick={() => navigate("/dns-servers/create")}>
+          <Button disabled={configMutationPending} onClick={() => navigate("/dns-servers/create")}>
             <Plus className="mr-1 h-4 w-4" />
             {t("pages.dnsServers.actions.add")}
           </Button>
@@ -95,13 +194,7 @@ export function DnsServersPage() {
         title={t("pages.dnsServers.title")}
       />
 
-      {mutationErrorMessage ? (
-        <Alert className="border-destructive/30 bg-destructive/5 text-destructive">
-          <AlertDescription className="whitespace-pre-wrap">
-            {mutationErrorMessage}
-          </AlertDescription>
-        </Alert>
-      ) : null}
+      <ConfigSaveErrorAlert error={postConfigMutation.error} />
 
       {configQuery.isLoading ? (
         <TableSkeleton />
@@ -117,51 +210,74 @@ export function DnsServersPage() {
           title={t("pages.dnsServers.empty.title")}
         />
       ) : (
-        <DataTable
-          headers={[
-            t("pages.dnsServers.headers.name"),
-            t("pages.dnsServers.headers.address"),
-            t("pages.dnsServers.headers.outbound"),
-            t("pages.dnsServers.headers.actions"),
-          ]}
-          rows={dnsServers.map((server) => [
-            <div className="font-medium" key={`${server.tag}-tag`}>
-              {server.tag}
-            </div>,
-            <span
-              className="text-sm text-muted-foreground"
-              key={`${server.tag}-address`}
+        <div className="space-y-3">
+          {selectedDnsServerTagsResolved.size > 0 ? (
+            <BulkSelectionToolbar
+              countLabel={t("pages.dnsServers.bulk.selected", {
+                count: selectedDnsServerTagsResolved.size,
+              })}
             >
-              {server.type === DnsServerType.keenetic
-                ? t("pages.dnsServers.keeneticAddress")
-                : server.address}
-            </span>,
-            <Badge
-              key={`${server.tag}-detour`}
-              variant={server.detour ? "outline" : "secondary"}
-            >
-              {server.detour || t("pages.dnsServers.none")}
-            </Badge>,
-            <ActionButtons
-              actions={[
-                {
-                  icon: <Pencil className="h-4 w-4" />,
-                  label: t("common.edit"),
-                  onClick: () =>
-                    navigate(
-                      `/dns-servers/${encodeURIComponent(server.tag)}/edit`
-                    ),
-                },
-                {
-                  icon: <Trash2 className="h-4 w-4" />,
-                  label: t("common.delete"),
-                  onClick: () => deleteServer(server.tag),
-                },
-              ]}
-              key={`${server.tag}-actions`}
-            />,
-          ])}
-        />
+              <Button
+                disabled={configMutationPending}
+                onClick={() => deleteServersBulk()}
+                size="sm"
+                variant="destructive"
+              >
+                <Trash2 className="mr-1 h-4 w-4" />
+                {t("pages.dnsServers.bulk.delete")}
+              </Button>
+            </BulkSelectionToolbar>
+          ) : null}
+          <DataTable
+            headers={[
+              t("pages.dnsServers.headers.name"),
+              t("pages.dnsServers.headers.address"),
+              t("pages.dnsServers.headers.outbound"),
+              t("pages.dnsServers.headers.actions"),
+            ]}
+            narrowColumns={[0]}
+            rows={dnsServers.map((server) => [
+              <div className="font-medium" key={`${server.tag}-tag`}>
+                {server.tag}
+              </div>,
+              <span
+                className="text-sm text-muted-foreground"
+                key={`${server.tag}-address`}
+              >
+                {server.type === DnsServerType.keenetic
+                  ? t("pages.dnsServers.keeneticAddress")
+                  : server.address}
+              </span>,
+              <Badge
+                key={`${server.tag}-detour`}
+                variant={server.detour ? "outline" : "secondary"}
+              >
+                {server.detour || t("pages.dnsServers.none")}
+              </Badge>,
+              <ActionButtons
+                actions={[
+                  {
+                    disabled: configMutationPending,
+                    icon: <Pencil className="h-4 w-4" />,
+                    label: t("common.edit"),
+                    onClick: () =>
+                      navigate(
+                        `/dns-servers/${encodeURIComponent(server.tag)}/edit`
+                      ),
+                  },
+                  {
+                    disabled: configMutationPending,
+                    icon: <Trash2 className="h-4 w-4" />,
+                    label: t("common.delete"),
+                    onClick: () => deleteServer(server.tag),
+                  },
+                ]}
+                key={`${server.tag}-actions`}
+              />,
+            ])}
+            selection={dnsServerSelectionProps}
+          />
+        </div>
       )}
     </div>
   )

--- a/frontend/src/pages/lists-page.tsx
+++ b/frontend/src/pages/lists-page.tsx
@@ -8,7 +8,7 @@ import { useLocation } from "wouter"
 import type { ApiError } from "@/api/client"
 import type { ConfigObject } from "@/api/generated/model/configObject"
 import type { ConfigStateResponseListRefreshState } from "@/api/generated/model/configStateResponseListRefreshState"
-import { usePostConfigMutation, usePostListsRefreshMutation } from "@/api/mutations"
+import { usePostConfigMutation, usePostListsRefreshMutation, useConfigMutationPending } from "@/api/mutations"
 import { queryKeys } from "@/api/query-keys"
 import { useGetConfig } from "@/api/queries"
 import {
@@ -17,12 +17,13 @@ import {
   selectListRefreshState,
 } from "@/api/selectors"
 import { ActionButtons } from "@/components/shared/action-buttons"
-import { DataTable } from "@/components/shared/data-table"
+import { BulkSelectionToolbar } from "@/components/shared/bulk-selection-toolbar"
+import { ConfigSaveErrorAlert } from "@/components/shared/config-save-error-alert"
+import { DataTable, type DataTableSelection } from "@/components/shared/data-table"
 import { ListPlaceholder } from "@/components/shared/list-placeholder"
 import { PageHeader } from "@/components/shared/page-header"
 import { StatsDisplay } from "@/components/shared/stats-display"
 import { TableSkeleton } from "@/components/shared/table-skeleton"
-import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { getApiErrorMessage } from "@/lib/api-errors"
@@ -56,23 +57,42 @@ const REFRESH_ALL_TARGET = "__all__"
 
 function isRefreshIconActive(
   activeRefreshTarget: string | null,
-  listId: string
+  bulkRefreshRunning: boolean,
+  selectedListIds: ReadonlySet<string>,
+  listId: string,
+  canRefresh?: boolean,
 ) {
-  return (
-    activeRefreshTarget === REFRESH_ALL_TARGET || activeRefreshTarget === listId
-  )
+  if (activeRefreshTarget === REFRESH_ALL_TARGET) {
+    return true
+  }
+
+  if (activeRefreshTarget === listId) {
+    return true
+  }
+
+  if (bulkRefreshRunning && canRefresh && selectedListIds.has(listId)) {
+    return true
+  }
+
+  return false
 }
+
 
 export function ListsPage() {
   const { t } = useTranslation()
   const [, navigate] = useLocation()
   const queryClient = useQueryClient()
+  const configMutationPending = useConfigMutationPending()
   const configQuery = useGetConfig()
   const loadedConfig = selectConfig(configQuery.data)
   const isDraft = selectConfigIsDraft(configQuery.data)
   const listRefreshState = selectListRefreshState(configQuery.data)
   const [activeRefreshTarget, setActiveRefreshTarget] = useState<string | null>(
-    null
+    null,
+  )
+  const [bulkRefreshRunning, setBulkRefreshRunning] = useState(false)
+  const [selectedListIds, setSelectedListIds] = useState<Set<string>>(
+    () => new Set(),
   )
 
   const listRefreshMutation = usePostListsRefreshMutation({
@@ -113,10 +133,28 @@ export function ListsPage() {
 
   const tableRows = useMemo(
     () => getTableRowsFromListMap(loadedConfig?.lists, listRefreshState, t),
-    [loadedConfig?.lists, listRefreshState, t]
+    [loadedConfig?.lists, listRefreshState, t],
   )
+
+  const validListIdSet = useMemo(
+    () => new Set(tableRows.map((row) => row.id)),
+    [tableRows],
+  )
+
+  const selectedListIdsResolved = useMemo(() => {
+    const next = new Set<string>()
+    for (const id of selectedListIds) {
+      if (validListIdSet.has(id)) {
+        next.add(id)
+      }
+    }
+
+    return next
+  }, [selectedListIds, validListIdSet])
+
   const hasRefreshableLists = tableRows.some((row) => row.canRefresh)
-  const refreshDisabled = listRefreshMutation.isPending
+  const refreshDisabled =
+    listRefreshMutation.isPending || configMutationPending
 
   const postConfigMutation = usePostConfigMutation({
     mutation: {
@@ -182,6 +220,102 @@ export function ListsPage() {
     listRefreshMutation.mutate({ data: { name: listId } })
   }
 
+  const handleBulkRefreshSelected = async () => {
+    if (isDraft) {
+      toast.warning(t("pages.lists.refresh.draftBlocked"), { richColors: true })
+      return
+    }
+
+    const ids = tableRows
+      .filter((row) => selectedListIdsResolved.has(row.id) && row.canRefresh)
+      .map((row) => row.id)
+    if (ids.length === 0) {
+      toast.warning(t("pages.lists.bulk.noUrlBacked"), { richColors: true })
+      return
+    }
+
+    setBulkRefreshRunning(true)
+    try {
+      for (const name of ids) {
+        await listRefreshMutation.mutateAsync({ data: { name } })
+      }
+
+      toast.success(
+        ids.length <= 1
+          ? t("pages.lists.messages.refreshedOne")
+          : t("pages.lists.messages.refreshedAll"),
+      )
+      setSelectedListIds(new Set())
+    } catch (error) {
+      toast.error(getApiErrorMessage(error as ApiError), { richColors: true })
+    } finally {
+      setBulkRefreshRunning(false)
+    }
+  }
+
+  const handleBulkDelete = () => {
+    if (!loadedConfig) {
+      return
+    }
+
+    const ids = [...selectedListIdsResolved]
+    const nextConfig = buildUpdatedConfigForListsDelete(loadedConfig, ids)
+    const refsChange = listDeletesAltersRoutingOrDnsRefs(loadedConfig, nextConfig)
+
+    const namesLabel = ids.join(", ")
+    const confirmed = window.confirm(
+      refsChange
+        ? t("pages.lists.bulk.confirmDeleteWithRefs", {
+            names: namesLabel,
+          })
+        : t("pages.lists.bulk.confirmDeleteSimple", {
+            names: namesLabel,
+          }),
+    )
+
+    if (!confirmed) {
+      return
+    }
+
+    postConfigMutation.mutate(
+      { data: nextConfig },
+      {
+        onSuccess: () => {
+          setSelectedListIds(new Set())
+        },
+      },
+    )
+  }
+
+  const listSelectionProps: DataTableSelection = {
+    rowIds: tableRows.map((row) => row.id),
+    selectedIds: selectedListIdsResolved,
+    selectionDisabled: configMutationPending,
+    selectAllAriaLabel: t("common.selection.selectAll"),
+    selectRowAriaLabel: (rowId: string) =>
+      t("common.selection.selectRow", { rowLabel: rowId }),
+    selectAllTooltip: t("common.selection.selectAll"),
+    onToggleRow: (rowId: string) => {
+      setSelectedListIds((previous) => {
+        const next = new Set(previous)
+        if (next.has(rowId)) {
+          next.delete(rowId)
+        } else {
+          next.add(rowId)
+        }
+
+        return next
+      })
+    },
+    onSelectAllVisible: (selectedAll: boolean) => {
+      if (selectedAll) {
+        setSelectedListIds(new Set(tableRows.map((row) => row.id)))
+      } else {
+        setSelectedListIds(new Set())
+      }
+    },
+  }
+
   return (
     <div className="space-y-6">
       <PageHeader
@@ -203,7 +337,7 @@ export function ListsPage() {
                 {t("pages.lists.actions.updateAll")}
               </Button>
             ) : null}
-            <Button onClick={() => navigate("/lists/create")}>
+            <Button disabled={configMutationPending} onClick={() => navigate("/lists/create")}>
               <Plus className="mr-1 h-4 w-4" />
               {t("pages.lists.actions.new")}
             </Button>
@@ -213,13 +347,7 @@ export function ListsPage() {
         title={t("pages.lists.title")}
       />
 
-      {postConfigMutation.error ? (
-        <Alert className="border-destructive/30 bg-destructive/5 text-destructive">
-          <AlertDescription className="whitespace-pre-wrap">
-            {getApiErrorMessage(postConfigMutation.error as ApiError)}
-          </AlertDescription>
-        </Alert>
-      ) : null}
+      <ConfigSaveErrorAlert error={postConfigMutation.error} />
 
       {configQuery.isLoading ? (
         <TableSkeleton />
@@ -235,15 +363,59 @@ export function ListsPage() {
           title={t("pages.lists.empty.title")}
         />
       ) : (
-        <DataTable
-          headers={[
-            t("pages.lists.headers.name"),
-            t("pages.lists.headers.type"),
-            t("pages.lists.headers.stats"),
-            t("pages.lists.headers.rules"),
-            t("pages.lists.headers.actions"),
-          ]}
-          rows={tableRows.map((list) => [
+        <div className="space-y-3">
+          {selectedListIdsResolved.size > 0 ? (
+            <BulkSelectionToolbar
+              countLabel={t("pages.lists.bulk.selected", {
+                count: selectedListIdsResolved.size,
+              })}
+            >
+              {hasRefreshableLists ? (
+                <Button
+                  disabled={
+                    refreshDisabled ||
+                    bulkRefreshRunning ||
+                    isDraft ||
+                    configMutationPending ||
+                    !tableRows.some(
+                      (row) =>
+                        selectedListIdsResolved.has(row.id) &&
+                        Boolean(row.canRefresh),
+                    )
+                  }
+                  onClick={() => void handleBulkRefreshSelected()}
+                  size="sm"
+                  variant="outline"
+                >
+                  <RefreshCw
+                    className={`mr-1 h-4 w-4 ${
+                      bulkRefreshRunning ? "animate-spin" : ""
+                    }`}
+                  />
+                  {t("pages.lists.bulk.refreshSelected")}
+                </Button>
+              ) : null}
+              <Button
+                disabled={configMutationPending}
+                onClick={() => handleBulkDelete()}
+                size="sm"
+                variant="destructive"
+              >
+                <Trash2 className="mr-1 h-4 w-4" />
+                {t("pages.lists.bulk.deleteSelected")}
+              </Button>
+            </BulkSelectionToolbar>
+          ) : null}
+          <DataTable
+            headers={[
+              t("pages.lists.headers.name"),
+              t("pages.lists.headers.type"),
+              t("pages.lists.headers.stats"),
+              t("pages.lists.headers.rules"),
+              t("pages.lists.headers.actions"),
+            ]}
+            narrowColumns={[0]}
+            rows={tableRows.map((list) => [
             <div className="space-y-1" key={`${list.id}-name`}>
               <div className="flex items-center gap-2 font-medium">
                 {list.draft.name}
@@ -299,11 +471,20 @@ export function ListsPage() {
                 ...(list.canRefresh
                   ? [
                       {
-                        disabled: refreshDisabled,
+                        disabled:
+                          refreshDisabled ||
+                          bulkRefreshRunning ||
+                          configMutationPending,
                         icon: (
                           <RefreshCw
                             className={`h-4 w-4 ${
-                              isRefreshIconActive(activeRefreshTarget, list.id)
+                              isRefreshIconActive(
+                                activeRefreshTarget,
+                                bulkRefreshRunning,
+                                selectedListIdsResolved,
+                                list.id,
+                                list.canRefresh,
+                              )
                                 ? "animate-spin"
                                 : ""
                             }`}
@@ -315,11 +496,13 @@ export function ListsPage() {
                     ]
                   : []),
                 {
+                  disabled: configMutationPending,
                   icon: <Pencil className="h-4 w-4" />,
                   label: t("common.edit"),
                   onClick: () => navigate(`/lists/${list.id}/edit`),
                 },
                 {
+                  disabled: configMutationPending,
                   icon: <Trash2 className="h-4 w-4" />,
                   label: t("common.delete"),
                   onClick: () => handleDelete(list.id),
@@ -328,7 +511,9 @@ export function ListsPage() {
               key={`${list.id}-actions`}
             />,
           ])}
-        />
+            selection={listSelectionProps}
+          />
+        </div>
       )}
     </div>
   )
@@ -386,6 +571,28 @@ function getTableRowsFromListMap(
       canRefresh: Boolean(listConfig.url),
     }
   })
+}
+
+function buildUpdatedConfigForListsDelete(
+  config: ConfigObject,
+  listIds: string[],
+): ConfigObject {
+  return listIds.reduce(
+    (acc, id) => buildUpdatedConfigForListDelete(acc, id),
+    config,
+  )
+}
+
+function listDeletesAltersRoutingOrDnsRefs(
+  before: ConfigObject,
+  after: ConfigObject,
+): boolean {
+  return (
+    JSON.stringify(before.route?.rules ?? []) !==
+      JSON.stringify(after.route?.rules ?? []) ||
+    JSON.stringify(before.dns?.rules ?? []) !==
+      JSON.stringify(after.dns?.rules ?? [])
+  )
 }
 
 function buildUpdatedConfigForListDelete(

--- a/frontend/src/pages/outbounds-page.tsx
+++ b/frontend/src/pages/outbounds-page.tsx
@@ -1,5 +1,5 @@
 import { Pencil, Plus, Trash2 } from "lucide-react"
-import type { ReactNode } from "react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { useQueryClient } from "@tanstack/react-query"
@@ -8,24 +8,16 @@ import { useLocation } from "wouter"
 import type { ApiError } from "@/api/client"
 import type { ConfigObject } from "@/api/generated/model/configObject"
 import type { Outbound } from "@/api/generated/model/outbound"
-import type { RuntimeInterfaceInventoryEntry } from "@/api/generated/model/runtimeInterfaceInventoryEntry"
 import type { RuntimeOutboundState } from "@/api/generated/model/runtimeOutboundState"
-import { usePostConfigMutation } from "@/api/mutations"
+import { usePostConfigMutation, useConfigMutationPending } from "@/api/mutations"
 import { queryKeys } from "@/api/query-keys"
-import {
-  useGetConfig,
-  useGetRuntimeInterfaces,
-  useGetRuntimeOutbounds,
-} from "@/api/queries"
+import { useGetConfig, useGetRuntimeOutbounds } from "@/api/queries"
 import { selectConfig, selectOutbounds } from "@/api/selectors"
 import { ActionButtons } from "@/components/shared/action-buttons"
-import { DataTable } from "@/components/shared/data-table"
-import { InterfaceRowContent } from "@/components/shared/interface-picker"
+import { BulkSelectionToolbar } from "@/components/shared/bulk-selection-toolbar"
+import { ConfigSaveErrorAlert } from "@/components/shared/config-save-error-alert"
+import { DataTable, type DataTableSelection } from "@/components/shared/data-table"
 import { ListPlaceholder } from "@/components/shared/list-placeholder"
-import {
-  RuntimeInterfaceStatusRow,
-  RuntimeStateBadge,
-} from "@/components/shared/outbound-interface-status-list"
 import { PageHeader } from "@/components/shared/page-header"
 import {
   RuntimeOutboundDetails,
@@ -41,9 +33,7 @@ type OutboundItem = {
   id: string
   tag: string
   type: Outbound["type"]
-  summary: ReactNode
-  outbound: Outbound
-  runtimeInterface?: RuntimeInterfaceInventoryEntry
+  summary: string
   runtimeState?: RuntimeOutboundState
 }
 
@@ -51,6 +41,7 @@ export function OutboundsPage() {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const [, navigate] = useLocation()
+  const configMutationPending = useConfigMutationPending()
   const configQuery = useGetConfig()
   const runtimeOutboundsQuery = useGetRuntimeOutbounds({
     query: {
@@ -58,35 +49,78 @@ export function OutboundsPage() {
       refetchIntervalInBackground: false,
     },
   })
-  const runtimeInterfacesQuery = useGetRuntimeInterfaces({
-    query: {
-      refetchInterval: 10_000,
-      refetchIntervalInBackground: false,
-    },
-  })
   const loadedConfig = selectConfig(configQuery.data)
-  // using toasts for mutation errors
 
-  const runtimeOutboundByTag = new Map(
-    (runtimeOutboundsQuery.data?.status === 200
-      ? runtimeOutboundsQuery.data.data.outbounds
-      : []
-    ).map((runtimeOutbound) => [runtimeOutbound.tag, runtimeOutbound])
+  const runtimeOutboundByTag = useMemo(
+    () =>
+      new Map(
+        (runtimeOutboundsQuery.data?.status === 200
+          ? runtimeOutboundsQuery.data.data.outbounds
+          : []
+        ).map((runtimeOutbound) => [runtimeOutbound.tag, runtimeOutbound]),
+      ),
+    [runtimeOutboundsQuery.data],
   )
-  const runtimeInterfaceByName = new Map(
-    (runtimeInterfacesQuery.data?.status === 200
-      ? runtimeInterfacesQuery.data.data.interfaces
-      : []
-    ).map((runtimeInterface) => [runtimeInterface.name, runtimeInterface])
+
+  const outboundItems = useMemo(
+    () =>
+      selectOutbounds(loadedConfig).map((outbound) =>
+        mapOutboundToItem(outbound, runtimeOutboundByTag.get(outbound.tag), t),
+      ),
+    [loadedConfig, runtimeOutboundByTag, t],
   )
-  const outboundItems = selectOutbounds(loadedConfig).map((outbound) =>
-    mapOutboundToItem(
-      outbound,
-      runtimeOutboundByTag.get(outbound.tag),
-      runtimeInterfaceByName.get(outbound.interface ?? ""),
-      t
-    )
+
+  const outboundRowIds = useMemo(
+    () => outboundItems.map((item) => item.id),
+    [outboundItems],
   )
+
+  const [selectedOutboundTags, setSelectedOutboundTags] = useState<Set<string>>(
+    () => new Set(),
+  )
+
+  const validOutboundIdSet = useMemo(
+    () => new Set(outboundRowIds),
+    [outboundRowIds],
+  )
+
+  const selectedOutboundTagsResolved = useMemo(() => {
+    const next = new Set<string>()
+    for (const id of selectedOutboundTags) {
+      if (validOutboundIdSet.has(id)) {
+        next.add(id)
+      }
+    }
+
+    return next
+  }, [selectedOutboundTags, validOutboundIdSet])
+
+  const outboundSelectionProps: DataTableSelection = {
+    rowIds: outboundRowIds,
+    selectedIds: selectedOutboundTagsResolved,
+    selectionDisabled: configMutationPending,
+    selectAllAriaLabel: t("common.selection.selectAll"),
+    selectRowAriaLabel: (tag: string) =>
+      t("common.selection.selectRow", { rowLabel: tag }),
+    selectAllTooltip: t("common.selection.selectAll"),
+    onToggleRow: (tag: string) => {
+      setSelectedOutboundTags((previous) => {
+        const next = new Set(previous)
+        if (next.has(tag)) {
+          next.delete(tag)
+        } else {
+          next.add(tag)
+        }
+
+        return next
+      })
+    },
+    onSelectAllVisible: (selectedAll: boolean) => {
+      setSelectedOutboundTags(
+        selectedAll ? new Set(outboundRowIds) : new Set(),
+      )
+    },
+  }
 
   const postConfigMutation = usePostConfigMutation({
     mutation: {
@@ -137,11 +171,54 @@ export function OutboundsPage() {
     postConfigMutation.mutate({ data: updatedConfig })
   }
 
+  const handleBulkDeleteOutbounds = () => {
+    if (!loadedConfig || selectedOutboundTagsResolved.size === 0) {
+      return
+    }
+
+    const confirmed = window.confirm(
+      t("pages.outbounds.bulk.confirmDelete", {
+        count: selectedOutboundTagsResolved.size,
+      }),
+    )
+
+    if (!confirmed) {
+      return
+    }
+
+    const nextOutbounds = selectOutbounds(loadedConfig).filter(
+      (item) => !selectedOutboundTagsResolved.has(item.tag),
+    )
+    const urltestReferencesError = validateUrltestGroupReferences(
+      nextOutbounds,
+      t,
+    )
+
+    if (urltestReferencesError) {
+      toast.error(urltestReferencesError, { richColors: true })
+      return
+    }
+
+    const updatedConfig: ConfigObject = {
+      ...loadedConfig,
+      outbounds: nextOutbounds,
+    }
+
+    postConfigMutation.mutate(
+      { data: updatedConfig },
+      {
+        onSuccess: () => {
+          setSelectedOutboundTags(new Set())
+        },
+      },
+    )
+  }
+
   return (
     <div className="space-y-6">
       <PageHeader
         actions={
-          <Button onClick={() => navigate("/outbounds/create")}>
+          <Button disabled={configMutationPending} onClick={() => navigate("/outbounds/create")}>
             <Plus className="mr-1 h-4 w-4" />
             {t("pages.outbounds.actions.new")}
           </Button>
@@ -149,6 +226,8 @@ export function OutboundsPage() {
         description={t("pages.outbounds.description")}
         title={t("pages.outbounds.title")}
       />
+
+      <ConfigSaveErrorAlert error={postConfigMutation.error} />
 
       {configQuery.isLoading ? (
         <TableSkeleton />
@@ -164,15 +243,34 @@ export function OutboundsPage() {
           title={t("pages.outbounds.empty.title")}
         />
       ) : (
-        <DataTable
-          headers={[
-            t("pages.outbounds.headers.tag"),
-            t("pages.outbounds.headers.type"),
-            t("pages.outbounds.headers.summary"),
-            t("pages.outbounds.headers.runtime"),
-            t("pages.outbounds.headers.actions"),
-          ]}
-          rows={outboundItems.map((outbound) => [
+        <div className="space-y-3">
+          {selectedOutboundTagsResolved.size > 0 ? (
+            <BulkSelectionToolbar
+              countLabel={t("pages.outbounds.bulk.selected", {
+                count: selectedOutboundTagsResolved.size,
+              })}
+            >
+              <Button
+                disabled={configMutationPending}
+                onClick={() => handleBulkDeleteOutbounds()}
+                size="sm"
+                variant="destructive"
+              >
+                <Trash2 className="mr-1 h-4 w-4" />
+                {t("pages.outbounds.bulk.delete")}
+              </Button>
+            </BulkSelectionToolbar>
+          ) : null}
+          <DataTable
+            headers={[
+              t("pages.outbounds.headers.tag"),
+              t("pages.outbounds.headers.type"),
+              t("pages.outbounds.headers.summary"),
+              t("pages.outbounds.headers.runtime"),
+              t("pages.outbounds.headers.actions"),
+            ]}
+            narrowColumns={[0]}
+            rows={outboundItems.map((outbound) => [
             <RuntimeOutboundEntry
               key={`${outbound.id}-tag`}
               runtimeState={outbound.runtimeState}
@@ -182,28 +280,30 @@ export function OutboundsPage() {
             <Badge key={`${outbound.id}-type`} variant="outline">
               {outbound.type}
             </Badge>,
-            <div
-              className="min-w-0 text-sm text-muted-foreground"
+            <span
+              className="text-sm text-muted-foreground"
               key={`${outbound.id}-summary`}
             >
               {outbound.summary}
-            </div>,
-            <OutboundRuntimeCell
+            </span>,
+            <RuntimeOutboundDetails
+              fallbackLabel={getRuntimeFallbackLabel(outbound, t)}
+              fallbackTone={getRuntimeFallbackTone(outbound)}
               key={`${outbound.id}-runtime`}
-              outbound={outbound.outbound}
-              runtimeInterface={outbound.runtimeInterface}
-              runtimeInterfaces={runtimeInterfaceByName}
               runtimeState={outbound.runtimeState}
               t={t}
+              variant="list"
             />,
             <ActionButtons
               actions={[
                 {
+                  disabled: configMutationPending,
                   icon: <Pencil className="h-4 w-4" />,
                   label: t("common.edit"),
                   onClick: () => navigate(`/outbounds/${outbound.id}/edit`),
                 },
                 {
+                  disabled: configMutationPending,
                   icon: <Trash2 className="h-4 w-4" />,
                   label: t("common.delete"),
                   onClick: () => handleDelete(outbound.id),
@@ -212,7 +312,9 @@ export function OutboundsPage() {
               key={`${outbound.id}-actions`}
             />,
           ])}
-        />
+            selection={outboundSelectionProps}
+          />
+        </div>
       )}
     </div>
   )
@@ -221,7 +323,6 @@ export function OutboundsPage() {
 function mapOutboundToItem(
   outbound: Outbound,
   runtimeState: RuntimeOutboundState | undefined,
-  runtimeInterface: RuntimeInterfaceInventoryEntry | undefined,
   t: (key: string, options?: Record<string, unknown>) => string
 ): OutboundItem {
   return {
@@ -229,8 +330,6 @@ function mapOutboundToItem(
     tag: outbound.tag,
     type: outbound.type,
     summary: getOutboundSummary(outbound, t),
-    outbound,
-    runtimeInterface,
     runtimeState,
   }
 }
@@ -238,7 +337,7 @@ function mapOutboundToItem(
 function getOutboundSummary(
   outbound: Outbound,
   t: (key: string, options?: Record<string, unknown>) => string
-): ReactNode {
+): string {
   if (outbound.type === "interface") {
     return t("pages.outbounds.summary.interface", {
       value: outbound.interface ?? "-",
@@ -260,99 +359,6 @@ function getOutboundSummary(
   }
 
   return t("common.noneShort")
-}
-
-function SummaryChip({ value }: { value: string }) {
-  return (
-    <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-      {value}
-    </code>
-  )
-}
-
-function OutboundRuntimeCell({
-  outbound,
-  runtimeState,
-  runtimeInterface,
-  runtimeInterfaces,
-  t,
-}: {
-  outbound: Outbound
-  runtimeState?: RuntimeOutboundState
-  runtimeInterface?: RuntimeInterfaceInventoryEntry
-  runtimeInterfaces: Map<string, RuntimeInterfaceInventoryEntry>
-  t: (key: string, options?: Record<string, unknown>) => string
-}) {
-  if (outbound.type === "interface") {
-    const runtimeInterfaceState = runtimeState?.interfaces[0]
-
-    return (
-      <RuntimeInterfaceStatusRow
-        item={{
-          name: outbound.interface ?? "-",
-          tone: getInterfaceRuntimeTone(runtimeInterfaceState?.status),
-        }}
-        variant="list"
-      >
-        <InterfaceRowContent
-          afterStatus={
-            runtimeInterfaceState ? (
-              <RuntimeStateBadge
-                active={runtimeInterfaceState.status === "active"}
-                label={t(`runtime.interfaceStatus.${runtimeInterfaceState.status}`)}
-                tone={getInterfaceRuntimeTone(runtimeInterfaceState.status)}
-              />
-            ) : null
-          }
-          grow={false}
-          interfaceEntry={runtimeInterface}
-          isVirtual={!runtimeInterface}
-          name={outbound.interface ?? "-"}
-        />
-        {outbound.gateway ? (
-          <SummaryChip
-            value={t("pages.outbounds.summary.gateway4", {
-              value: outbound.gateway,
-            })}
-          />
-        ) : null}
-        {outbound.gateway6 ? (
-          <SummaryChip
-            value={t("pages.outbounds.summary.gateway6", {
-              value: outbound.gateway6,
-            })}
-          />
-        ) : null}
-      </RuntimeInterfaceStatusRow>
-    )
-  }
-
-  return (
-    <RuntimeOutboundDetails
-      fallbackLabel={getRuntimeFallbackLabel(outbound, t)}
-      fallbackTone={getRuntimeFallbackTone(outbound)}
-      runtimeState={runtimeState}
-      runtimeInterfaces={runtimeInterfaces}
-      t={t}
-      variant="list"
-    />
-  )
-}
-
-function getInterfaceRuntimeTone(
-  status?: RuntimeOutboundState["interfaces"][number]["status"]
-) {
-  switch (status) {
-    case "active":
-    case "backup":
-      return "healthy"
-    case "degraded":
-    case "unavailable":
-      return "degraded"
-    case "unknown":
-    default:
-      return "unknown"
-  }
 }
 
 function getRuntimeFallbackLabel(

--- a/frontend/src/pages/routing-rules-page.tsx
+++ b/frontend/src/pages/routing-rules-page.tsx
@@ -1,16 +1,18 @@
 import { ArrowDown, ArrowUp, Pencil, Plus, Trash2 } from "lucide-react"
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useLocation } from "wouter"
 
 import type { ApiError } from "@/api/client"
 import type { RouteRule } from "@/api/generated/model/routeRule"
-import { usePostConfigMutation } from "@/api/mutations"
+import { usePostConfigMutation, useConfigMutationPending } from "@/api/mutations"
 import type { RuntimeOutboundState } from "@/api/generated/model"
 import { useGetConfig, useGetRuntimeOutbounds } from "@/api/queries"
 import { selectConfig } from "@/api/selectors"
 import { ActionButtons } from "@/components/shared/action-buttons"
-import { DataTable } from "@/components/shared/data-table"
+import { BulkSelectionToolbar } from "@/components/shared/bulk-selection-toolbar"
+import { ConfigSaveErrorAlert } from "@/components/shared/config-save-error-alert"
+import { DataTable, type DataTableSelection } from "@/components/shared/data-table"
 import { ListPlaceholder } from "@/components/shared/list-placeholder"
 import { PageHeader } from "@/components/shared/page-header"
 import { RuntimeOutboundEntry } from "@/components/shared/runtime-outbound-state"
@@ -28,10 +30,37 @@ export function RoutingRulesPage() {
   const { t } = useTranslation()
   const [, navigate] = useLocation()
 
-
+  const configMutationPending = useConfigMutationPending()
   const configQuery = useGetConfig()
   const loadedConfig = selectConfig(configQuery.data)
-  const routeRules = loadedConfig?.route?.rules ?? []
+  const routeRules = useMemo(
+    () => loadedConfig?.route?.rules ?? [],
+    [loadedConfig?.route?.rules],
+  )
+
+  const [selectedRuleIndices, setSelectedRuleIndices] = useState<Set<string>>(
+    () => new Set(),
+  )
+
+  const validRuleIndexSet = useMemo(
+    () =>
+      new Set(
+        routeRules.map((_rule: RouteRule, ruleIndex: number) => String(ruleIndex)),
+      ),
+    [routeRules],
+  )
+
+  const selectedRuleIndicesResolved = useMemo(() => {
+    const next = new Set<string>()
+    for (const id of selectedRuleIndices) {
+      if (validRuleIndexSet.has(id)) {
+        next.add(id)
+      }
+    }
+
+    return next
+  }, [selectedRuleIndices, validRuleIndexSet])
+
   const runtimeOutboundsQuery = useGetRuntimeOutbounds({
     query: {
       refetchInterval: 10_000,
@@ -72,17 +101,27 @@ export function RoutingRulesPage() {
 
   const persistRules = (
     config: NonNullable<typeof loadedConfig>,
-    nextRules: RouteRule[]
+    nextRules: RouteRule[],
+    options?: { clearSelection?: boolean },
   ) => {
-    postConfigMutation.mutate({
-      data: {
-        ...config,
-        route: {
-          ...config.route,
-          rules: nextRules,
+    postConfigMutation.mutate(
+      {
+        data: {
+          ...config,
+          route: {
+            ...config.route,
+            rules: nextRules,
+          },
         },
       },
-    })
+      options?.clearSelection
+        ? {
+            onSuccess: () => {
+              setSelectedRuleIndices(new Set())
+            },
+          }
+        : undefined,
+    )
   }
 
   const handleDelete = (index: number) => {
@@ -118,11 +157,75 @@ export function RoutingRulesPage() {
     persistRules(loadedConfig, setRouteRuleEnabled(routeRules, index, enabled))
   }
 
+  const handleBulkDelete = () => {
+    if (!loadedConfig || selectedRuleIndicesResolved.size === 0) {
+      return
+    }
+
+    const confirmed = window.confirm(
+      t("pages.routingRules.bulk.confirmDelete", {
+        count: selectedRuleIndicesResolved.size,
+      }),
+    )
+    if (!confirmed) {
+      return
+    }
+
+    const nextRules = routeRules.filter(
+      (_rule: RouteRule, ruleIndex: number) =>
+        !selectedRuleIndicesResolved.has(String(ruleIndex)),
+    )
+    persistRules(loadedConfig, nextRules, { clearSelection: true })
+  }
+
+  const handleBulkSetEnabled = (enabled: boolean) => {
+    if (!loadedConfig || selectedRuleIndicesResolved.size === 0) {
+      return
+    }
+
+    const nextRules = routeRules.map((rule: RouteRule, ruleIndex: number) =>
+      selectedRuleIndicesResolved.has(String(ruleIndex))
+        ? { ...rule, enabled }
+        : rule,
+    )
+    persistRules(loadedConfig, nextRules)
+  }
+
+  const ruleSelectionProps: DataTableSelection = {
+    rowIds: routeRules.map((_rule: RouteRule, index: number) => String(index)),
+    selectedIds: selectedRuleIndicesResolved,
+    selectionDisabled: configMutationPending,
+    selectAllAriaLabel: t("common.selection.selectAll"),
+    selectRowAriaLabel: (rowId: string) =>
+      t("common.selection.selectRow", {
+        rowLabel:
+          `${t("pages.routingRules.title")} #${Number(rowId) + 1}`,
+      }),
+    selectAllTooltip: t("common.selection.selectAll"),
+    onToggleRow: (rowId: string) => {
+      setSelectedRuleIndices((previous) => {
+        const next = new Set(previous)
+        if (next.has(rowId)) {
+          next.delete(rowId)
+        } else {
+          next.add(rowId)
+        }
+
+        return next
+      })
+    },
+    onSelectAllVisible: (selectedAll: boolean) => {
+      setSelectedRuleIndices(
+        selectedAll ? new Set(routeRules.map((_r, idx) => String(idx))) : new Set(),
+      )
+    },
+  }
+
   return (
     <div className="space-y-6">
       <PageHeader
         actions={
-          <Button onClick={() => navigate("/routing-rules/create")}>
+          <Button disabled={configMutationPending} onClick={() => navigate("/routing-rules/create")}>
             <Plus className="mr-1 h-4 w-4" />
             {t("pages.routingRules.actions.addRule")}
           </Button>
@@ -131,7 +234,7 @@ export function RoutingRulesPage() {
         title={t("pages.routingRules.title")}
       />
 
-
+      <ConfigSaveErrorAlert error={postConfigMutation.error} />
 
       {configQuery.isLoading ? (
         <TableSkeleton />
@@ -147,16 +250,45 @@ export function RoutingRulesPage() {
           title={t("pages.routingRules.empty.title")}
         />
       ) : (
-        <DataTable
-          headers={[
-            "",
-            t("pages.routingRules.headers.order"),
-            t("pages.routingRules.headers.criteria"),
-            t("pages.routingRules.headers.outbound"),
-            t("pages.routingRules.headers.actions"),
-          ]}
-          narrowColumns={[0, 1]}
-          rows={tableRows.map((row: ReturnType<typeof getRouteRuleRow>) => [
+        <div className="space-y-3">
+          {selectedRuleIndicesResolved.size > 0 ? (
+            <BulkSelectionToolbar
+              countLabel={t("pages.routingRules.bulk.selected", {
+                count: selectedRuleIndicesResolved.size,
+              })}
+            >
+              <Button
+                disabled={configMutationPending}
+                onClick={() => handleBulkSetEnabled(true)}
+                size="sm"
+                variant="outline"
+              >
+                {t("pages.routingRules.bulk.enable")}
+              </Button>
+              <Button
+                disabled={configMutationPending}
+                onClick={() => handleBulkSetEnabled(false)}
+                size="sm"
+                variant="outline"
+              >
+                {t("pages.routingRules.bulk.disable")}
+              </Button>
+              <Button disabled={configMutationPending} onClick={() => handleBulkDelete()} size="sm" variant="destructive">
+                <Trash2 className="mr-1 h-4 w-4" />
+                {t("pages.routingRules.bulk.delete")}
+              </Button>
+            </BulkSelectionToolbar>
+          ) : null}
+          <DataTable
+            headers={[
+              "",
+              t("pages.routingRules.headers.order"),
+              t("pages.routingRules.headers.criteria"),
+              t("pages.routingRules.headers.outbound"),
+              t("pages.routingRules.headers.actions"),
+            ]}
+            narrowColumns={[0, 1, 2]}
+            rows={tableRows.map((row: ReturnType<typeof getRouteRuleRow>) => [
             <div className="flex items-center" key={`${row.id}-enabled`}>
               <Switch
                 aria-label={t(
@@ -165,6 +297,7 @@ export function RoutingRulesPage() {
                     : "pages.routingRules.actions.enableRule"
                 )}
                 checked={row.enabled}
+                disabled={configMutationPending}
                 onCheckedChange={(checked) => handleEnabledChange(row.index, checked)}
                 title={t(
                   row.enabled
@@ -202,21 +335,25 @@ export function RoutingRulesPage() {
             <ActionButtons
               actions={[
                 {
+                  disabled: configMutationPending,
                   icon: <ArrowUp className="h-4 w-4" />,
                   label: t("common.moveUp"),
                   onClick: () => handleMove(row.index, -1),
                 },
                 {
+                  disabled: configMutationPending,
                   icon: <ArrowDown className="h-4 w-4" />,
                   label: t("common.moveDown"),
                   onClick: () => handleMove(row.index, 1),
                 },
                 {
+                  disabled: configMutationPending,
                   icon: <Pencil className="h-4 w-4" />,
                   label: t("common.edit"),
                   onClick: () => navigate(`/routing-rules/${row.index}/edit`),
                 },
                 {
+                  disabled: configMutationPending,
                   icon: <Trash2 className="h-4 w-4" />,
                   label: t("common.delete"),
                   onClick: () => handleDelete(row.index),
@@ -225,7 +362,9 @@ export function RoutingRulesPage() {
               key={`${row.id}-actions`}
             />,
           ])}
-        />
+            selection={ruleSelectionProps}
+          />
+        </div>
       )}
     </div>
   )

--- a/frontend/tests/config-mutation-pending.test.ts
+++ b/frontend/tests/config-mutation-pending.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+
+import { isConfigMutationPending } from "../src/api/mutations"
+
+describe("isConfigMutationPending", () => {
+  test("returns false when no config mutations are in flight", () => {
+    expect(isConfigMutationPending(0, 0)).toBe(false)
+  })
+
+  test("returns true when draft save is in flight", () => {
+    expect(isConfigMutationPending(1, 0)).toBe(true)
+  })
+
+  test("returns true when apply save is in flight", () => {
+    expect(isConfigMutationPending(0, 2)).toBe(true)
+  })
+})


### PR DESCRIPTION
Part of splitting #125 into smaller, single-purpose PRs, as you requested in the review.

The routing-rules, outbounds, DNS-rules, DNS-servers and lists screens managed rows one at a time. This adds row selection and a bulk toolbar:

- `DataTable` gains an optional selection column with a "select all visible" header checkbox and a shared `BulkSelectionToolbar`.
- Each table screen gets the bulk actions that make sense — delete, enable/disable, and update-by-URL for lists. Deletes are reference-aware and offer to clean up dangling routing/DNS references.
- Selection state is derived against the current rows, so rows that disappear after a refetch drop out of the selection cleanly.
- Config-save failures surface through a shared `ConfigSaveErrorAlert`; a `useConfigMutationPending` hook disables checkboxes/toggles/bulk buttons while a draft or apply write is in flight, to avoid double submits.

Frontend lint + production build pass.