### PR TITLE
feat(ui): show a concise "also in" hint when picking a list for a rule

### DIFF
--- a/frontend/src/components/shared/multi-select-list.tsx
+++ b/frontend/src/components/shared/multi-select-list.tsx
@@ -8,6 +8,31 @@ import { FieldError } from "@/components/shared/field"
 import { InputGroup, InputGroupAddon, InputGroupButton } from "@/components/ui/input-group"
 import { cn } from "@/lib/utils"
 
+function OptionLabel({
+  option,
+  usageSubtitle,
+  renderItem,
+}: {
+  option: string
+  usageSubtitle?: (optionName: string) => string | undefined
+  renderItem?: (item: string) => ReactNode
+}) {
+  const usage = usageSubtitle?.(option)
+
+  if (!usage) {
+    return <>{renderItem ? renderItem(option) : option}</>
+  }
+
+  return (
+    <span className="flex max-w-[min(100vw-4rem,24rem)] flex-col items-start gap-0.5 py-0.5">
+      <span>{renderItem ? renderItem(option) : option}</span>
+      <span className="break-words text-xs whitespace-normal text-muted-foreground">
+        {usage}
+      </span>
+    </span>
+  )
+}
+
 export function MultiSelectList({
   name,
   options,
@@ -19,6 +44,7 @@ export function MultiSelectList({
   placeholderTitle,
   placeholderDescription,
   allowReorder = false,
+  usageSubtitle,
   error,
   renderItem,
   getSearchText,
@@ -34,6 +60,8 @@ export function MultiSelectList({
   placeholderTitle?: string
   placeholderDescription?: string
   allowReorder?: boolean
+  /** Hint shown under each option label (dropdown + chosen rows). */
+  usageSubtitle?: (optionName: string) => string | undefined
   error?: string | null
   renderItem?: (item: string) => ReactNode
   getSearchText?: (item: string) => string
@@ -43,7 +71,7 @@ export function MultiSelectList({
   const selectedSet = new Set(value)
   const unavailableSet = new Set(unavailable)
   const availableOptions = options.filter(
-    (option) => !selectedSet.has(option) && !unavailableSet.has(option)
+    (option) => !selectedSet.has(option) && !unavailableSet.has(option),
   )
   const filteredOptions = useMemo(() => {
     const normalizedValue = selectValue.trim().toLowerCase()
@@ -53,7 +81,7 @@ export function MultiSelectList({
     }
 
     return availableOptions.filter((option) =>
-      (getSearchText?.(option) ?? option).toLowerCase().includes(normalizedValue)
+      (getSearchText?.(option) ?? option).toLowerCase().includes(normalizedValue),
     )
   }, [availableOptions, getSearchText, selectValue])
 
@@ -73,7 +101,8 @@ export function MultiSelectList({
     onChange([...value, nextValue])
     setSelectValue("")
   }
-  const shouldRenderPopup = filteredOptions.length > 0 || Boolean(selectValue.trim())
+  const shouldRenderPopup =
+    filteredOptions.length > 0 || Boolean(selectValue.trim())
   const addSelect = (
     <Autocomplete.Root
       items={filteredOptions}
@@ -118,11 +147,16 @@ export function MultiSelectList({
                   {(option: string, index) => (
                     <Autocomplete.Item
                       className="cursor-default rounded-md px-2 py-1.5 text-sm outline-hidden select-none hover:bg-accent hover:text-accent-foreground data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                      data-list-option={option}
                       index={index}
                       key={option}
                       value={option}
                     >
-                      {renderItem ? renderItem(option) : option}
+                      <OptionLabel
+                        option={option}
+                        renderItem={renderItem}
+                        usageSubtitle={usageSubtitle}
+                      />
                     </Autocomplete.Item>
                   )}
                 </Autocomplete.List>
@@ -141,18 +175,32 @@ export function MultiSelectList({
   return (
     <div className="space-y-2" data-field-name={name}>
       {value.length ? (
-        <div className={cn("space-y-2 rounded-xl border p-3", error ? "border-destructive" : "border-border")}>
+        <div
+          className={cn(
+            "space-y-2 rounded-xl border p-3",
+            error ? "border-destructive" : "border-border",
+          )}
+        >
           {value.map((item, index) => (
-            <InputGroup key={`${item}-${index}`} className="h-auto min-h-8 cursor-default">
-              <InputGroupAddon className="w-full justify-start text-foreground">
-                {renderItem ? renderItem(item) : item}
+            <InputGroup
+              key={`${item}-${index}`}
+              className="h-auto min-h-8 cursor-default"
+            >
+              <InputGroupAddon className="w-full flex-col items-stretch gap-0.5 text-left text-foreground">
+                <OptionLabel
+                  option={item}
+                  renderItem={renderItem}
+                  usageSubtitle={usageSubtitle}
+                />
               </InputGroupAddon>
               <InputGroupAddon align="inline-end">
                 <InputGroupButton
                   aria-label={t("common.multiSelectList.removeItem", { item })}
                   className="text-destructive hover:text-destructive"
                   onClick={() =>
-                    onChange(value.filter((_, currentIndex) => currentIndex !== index))
+                    onChange(
+                      value.filter((_, currentIndex) => currentIndex !== index),
+                    )
                   }
                   size="icon-xs"
                 >
@@ -168,10 +216,10 @@ export function MultiSelectList({
                           return
                         }
                         const nextValue = [...value]
-                          ;[nextValue[index - 1], nextValue[index]] = [
-                            nextValue[index],
-                            nextValue[index - 1],
-                          ]
+                        ;[nextValue[index - 1], nextValue[index]] = [
+                          nextValue[index],
+                          nextValue[index - 1],
+                        ]
                         onChange(nextValue)
                       }}
                       size="icon-xs"
@@ -186,10 +234,10 @@ export function MultiSelectList({
                           return
                         }
                         const nextValue = [...value]
-                          ;[nextValue[index], nextValue[index + 1]] = [
-                            nextValue[index + 1],
-                            nextValue[index],
-                          ]
+                        ;[nextValue[index], nextValue[index + 1]] = [
+                          nextValue[index + 1],
+                          nextValue[index],
+                        ]
                         onChange(nextValue)
                       }}
                       size="icon-xs"
@@ -204,15 +252,24 @@ export function MultiSelectList({
           <div>{addSelect}</div>
         </div>
       ) : (
-        <div className={cn("space-y-3 rounded-xl border p-3", error ? "border-destructive" : "border-border")}>
+        <div
+          className={cn(
+            "space-y-3 rounded-xl border p-3",
+            error ? "border-destructive" : "border-border",
+          )}
+        >
           <div className="flex items-start gap-3">
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted/50">
               <ListPlus className="h-5 w-5 text-muted-foreground" />
             </div>
             <div className="mt-0.5 flex flex-col gap-0.5">
-              <span className="text-sm font-medium text-foreground">{resolvedPlaceholderTitle}</span>
+              <span className="text-sm font-medium text-foreground">
+                {resolvedPlaceholderTitle}
+              </span>
               {resolvedPlaceholderDescription ? (
-                <span className="text-sm text-muted-foreground">{resolvedPlaceholderDescription}</span>
+                <span className="text-sm text-muted-foreground">
+                  {resolvedPlaceholderDescription}
+                </span>
               ) : null}
             </div>
           </div>

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -512,6 +512,7 @@ export const enTranslation = {
               "Add one or more configured list names to match for this rule.",
             noListsSelected: "No lists selected",
             listsHint: "Choose which of your lists this rule applies to.",
+            listUsedElsewhere: "Also in: {{summary}}",
             proto: "Proto",
             any: "Any",
             anyLower: "any",
@@ -769,6 +770,7 @@ export const enTranslation = {
             listPlaceholderDescription:
               "Choose which lists this rule applies to. Matching domains will use this DNS server.",
             noListsSelected: "No lists selected",
+            listUsedElsewhere: "Also in: {{summary}}",
             noLists:
               "No lists found. Please, create first filter on the Lists page.",
           },

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -41,6 +41,10 @@ function detectInitialLanguage(): Language {
   }
 
   const preferred = navigator.languages?.[0] ?? navigator.language
+  if (!preferred) {
+    return DEFAULT_LANGUAGE
+  }
+
   return preferred.toLowerCase().startsWith("ru") ? "ru" : DEFAULT_LANGUAGE
 }
 

--- a/frontend/src/i18n/ru.ts
+++ b/frontend/src/i18n/ru.ts
@@ -522,6 +522,7 @@ export const ruTranslation = {
               "Добавьте один или несколько настроенных списков для этого правила.",
             noListsSelected: "Списки не выбраны",
             listsHint: "Выберите, к каким спискам применяется это правило.",
+            listUsedElsewhere: "Используется ещё в: {{summary}}",
             proto: "Протокол",
             any: "Любой",
             anyLower: "любой",
@@ -790,6 +791,7 @@ export const ruTranslation = {
             listPlaceholderDescription:
               "Выберите списки для этого правила. Совпадающие домены будут использовать этот DNS-сервер.",
             noListsSelected: "Списки не выбраны",
+            listUsedElsewhere: "Используется ещё в: {{summary}}",
             noLists:
               "Не найдено ни одного списка. Пожалуйста, сначала создайте его на странице Списки.",
           },

--- a/frontend/src/pages/dns-rule-upsert-page.tsx
+++ b/frontend/src/pages/dns-rule-upsert-page.tsx
@@ -5,6 +5,7 @@ import { useLocation } from "wouter"
 import { useForm } from "@tanstack/react-form"
 import { useQueryClient } from "@tanstack/react-query"
 import { useStore } from "@tanstack/react-store"
+import { useMemo } from "react"
 
 import type { ApiError } from "@/api/client"
 import type { ConfigObject } from "@/api/generated/model/configObject"
@@ -40,7 +41,9 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import {
+  buildListUsageByDnsRules,
   buildUpdatedConfigWithRules,
+  formatDnsListRefsUsageSummary,
   getRuleDraft,
   validateRules,
 } from "@/pages/dns-rules-utils"
@@ -153,6 +156,15 @@ function DnsRuleForm({
     label: serverTag,
   }))
   const listOptions = Object.keys(loadedConfig.lists ?? {})
+  const dnsRuleDrafts = useMemo(() => rules.map((rule) => getRuleDraft(rule)), [rules])
+  const dnsListUsageByName = useMemo(
+    () =>
+      buildListUsageByDnsRules(
+        dnsRuleDrafts,
+        mode === "edit" ? parsedRuleIndex : undefined,
+      ),
+    [dnsRuleDrafts, mode, parsedRuleIndex],
+  )
   const postConfigMutation = usePostConfigMutation()
   const form = useForm({
     defaultValues: {
@@ -374,6 +386,15 @@ function DnsRuleForm({
                       placeholderTitle={t(
                         "pages.dnsRuleUpsert.fields.noListsSelected"
                       )}
+                      usageSubtitle={(optionName) => {
+                        const refs = dnsListUsageByName.get(optionName)
+                        if (!refs?.length) {
+                          return undefined
+                        }
+                        return t("pages.dnsRuleUpsert.fields.listUsedElsewhere", {
+                          summary: formatDnsListRefsUsageSummary(refs),
+                        })
+                      }}
                       value={field.state.value}
                     />
                     <FieldHint

--- a/frontend/src/pages/dns-rules-utils.ts
+++ b/frontend/src/pages/dns-rules-utils.ts
@@ -58,6 +58,59 @@ export function setDnsRuleEnabled(
   )
 }
 
+export type DnsListUsageRef = {
+  ruleIndex: number
+  server: string
+}
+
+type DnsRuleListSource = {
+  server: string
+  list?: string[]
+  lists?: string[]
+}
+
+function ruleListNames(rule: DnsRuleListSource): string[] {
+  return rule.lists ?? rule.list ?? []
+}
+
+/** Builds a map of list name → other DNS rules referencing that list. */
+export function buildListUsageByDnsRules(
+  rules: DnsRuleListSource[],
+  excludeRuleIndex?: number,
+): Map<string, DnsListUsageRef[]> {
+  const map = new Map<string, DnsListUsageRef[]>()
+
+  rules.forEach((rule, index) => {
+    if (excludeRuleIndex !== undefined && index === excludeRuleIndex) {
+      return
+    }
+
+    const server = rule.server
+    for (const listName of ruleListNames(rule)) {
+      if (!listName) {
+        continue
+      }
+      const prev = map.get(listName) ?? []
+      prev.push({ ruleIndex: index, server })
+      map.set(listName, prev)
+    }
+  })
+
+  return map
+}
+
+export function describeDnsRuleRefForListUsage(
+  ref: DnsListUsageRef,
+): string {
+  return `#${ref.ruleIndex + 1} → ${ref.server}`
+}
+
+export function formatDnsListRefsUsageSummary(
+  refs: DnsListUsageRef[],
+): string {
+  return refs.map((reference) => describeDnsRuleRefForListUsage(reference)).join(", ")
+}
+
 export function validateRules(
   rules: DnsRuleDraft[],
   serverTags: string[],

--- a/frontend/src/pages/routing-rule-upsert-page.tsx
+++ b/frontend/src/pages/routing-rule-upsert-page.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useLocation } from "wouter"
 
@@ -41,7 +42,9 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import {
+  buildListUsageByRouteRules,
   emptyRouteRuleDraft,
+  formatRoutingListRefsUsageSummary,
   getFirstFieldError,
   normalizeRouteRuleDraft,
   protoOptions,
@@ -155,11 +158,19 @@ function RoutingRuleForm({
   )
   const outbounds = (loadedConfig.outbounds ?? [])
     .filter((outbound: Outbound): outbound is Outbound & { tag: string } =>
-      Boolean(outbound.tag)
+      Boolean(outbound.tag),
     )
     .sort((left: Outbound, right: Outbound) =>
-      left.tag.localeCompare(right.tag)
+      left.tag.localeCompare(right.tag),
     )
+  const routingListUsageByName = useMemo(
+    () =>
+      buildListUsageByRouteRules(
+        rules,
+        mode === "edit" ? parsedRuleIndex : undefined,
+      ),
+    [rules, mode, parsedRuleIndex],
+  )
   const protoSelectItems = protoOptions.map((option) => ({
     value: option,
     label: option || t("pages.routingRuleUpsert.fields.anyLower"),
@@ -322,6 +333,19 @@ function RoutingRuleForm({
                       placeholderTitle={t(
                         "pages.routingRuleUpsert.fields.noListsSelected"
                       )}
+                      usageSubtitle={(optionName) => {
+                        const refs = routingListUsageByName.get(optionName)
+                        if (!refs?.length) {
+                          return undefined
+                        }
+
+                        return t(
+                          "pages.routingRuleUpsert.fields.listUsedElsewhere",
+                          {
+                            summary: formatRoutingListRefsUsageSummary(refs),
+                          },
+                        )
+                      }}
                       value={field.state.value}
                     />
                     <FieldHint

--- a/frontend/src/pages/routing-rules-utils.ts
+++ b/frontend/src/pages/routing-rules-utils.ts
@@ -84,6 +84,51 @@ export function setRouteRuleEnabled(
   )
 }
 
+export type RouteListUsageRef = {
+  ruleIndex: number
+  outbound: string
+}
+
+/** Builds a map of list name → other routing rules referencing that list. */
+export function buildListUsageByRouteRules(
+  rules: RouteRule[],
+  excludeRuleIndex?: number
+): Map<string, RouteListUsageRef[]> {
+  const map = new Map<string, RouteListUsageRef[]>()
+  rules.forEach((rule, index) => {
+    if (
+      excludeRuleIndex !== undefined &&
+      index === excludeRuleIndex
+    ) {
+      return
+    }
+
+    const outbound = rule.outbound
+    for (const listName of rule.list ?? []) {
+      if (!listName) {
+        continue
+      }
+      const prev = map.get(listName) ?? []
+      prev.push({ ruleIndex: index, outbound })
+      map.set(listName, prev)
+    }
+  })
+  return map
+}
+
+export function describeRouteRuleRefForListUsage(
+  ref: RouteListUsageRef,
+): string {
+  return `#${ref.ruleIndex + 1} → ${ref.outbound}`
+}
+
+/** Single-line subtitle for list pickers: other routing rules referencing the same list. */
+export function formatRoutingListRefsUsageSummary(
+  refs: RouteListUsageRef[],
+): string {
+  return refs.map((reference) => describeRouteRuleRefForListUsage(reference)).join(", ")
+}
+
 export function getFirstFieldError(errors: unknown[]) {
   const firstError = errors[0]
   return typeof firstError === "string" ? firstError : undefined

--- a/frontend/tests/dns-rules-list-usage-summary.test.ts
+++ b/frontend/tests/dns-rules-list-usage-summary.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  buildListUsageByDnsRules,
+  describeDnsRuleRefForListUsage,
+  formatDnsListRefsUsageSummary,
+} from "../src/pages/dns-rules-utils"
+
+describe("DNS list usage helpers", () => {
+  test("buildListUsageByDnsRules aggregates lists and excludes index", () => {
+    const rules = [
+      { server: "upstream", lists: ["a", "b"] },
+      { server: "backup", list: ["a"] },
+    ]
+
+    const all = buildListUsageByDnsRules(rules)
+    expect(all.get("a")?.length).toBe(2)
+    expect(all.get("b")?.length).toBe(1)
+
+    const edit0 = buildListUsageByDnsRules(rules, 0)
+    expect(edit0.get("a")?.length).toBe(1)
+    expect(edit0.get("a")?.[0]?.server).toBe("backup")
+    expect(edit0.get("b")).toBeUndefined()
+  })
+
+  test("formatDnsListRefsUsageSummary shows rule number and server only, joined by comma", () => {
+    const rules = [
+      { server: "upstream", lists: ["shared"] },
+      { server: "backup", lists: ["shared", "other"] },
+    ]
+    const refs = buildListUsageByDnsRules(rules).get("shared") ?? []
+    const summary = formatDnsListRefsUsageSummary(refs)
+
+    expect(summary).toContain("#1 → upstream")
+    expect(summary).toContain("#2 → backup")
+    expect(summary).toContain(", ")
+    expect(summary).not.toContain("lists:")
+    expect(summary).not.toContain(" • ")
+  })
+
+  test("describeDnsRuleRefForListUsage returns index and server", () => {
+    expect(
+      describeDnsRuleRefForListUsage({ ruleIndex: 1, server: "upstream" }),
+    ).toBe("#2 → upstream")
+  })
+})

--- a/frontend/tests/routing-rules-list-usage-summary.test.ts
+++ b/frontend/tests/routing-rules-list-usage-summary.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+
+import type { RouteRule } from "../src/api/generated/model/routeRule"
+import {
+  buildListUsageByRouteRules,
+  describeRouteRuleRefForListUsage,
+  formatRoutingListRefsUsageSummary,
+} from "../src/pages/routing-rules-utils"
+
+function rule(partial: RouteRule): RouteRule {
+  return partial
+}
+
+describe("routing list usage helpers", () => {
+  test("buildListUsageByRouteRules aggregates lists and excludes index", () => {
+    const rules: RouteRule[] = [
+      rule({ outbound: "wan", list: ["a", "b"] }),
+      rule({ outbound: "vpn", list: ["a"] }),
+    ]
+
+    const all = buildListUsageByRouteRules(rules)
+    expect(all.get("a")?.length).toBe(2)
+    expect(all.get("b")?.length).toBe(1)
+
+    const edit0 = buildListUsageByRouteRules(rules, 0)
+    expect(edit0.get("a")?.length).toBe(1)
+    expect(edit0.get("a")?.[0]?.outbound).toBe("vpn")
+    expect(edit0.get("b")).toBeUndefined()
+  })
+
+  test("formatRoutingListRefsUsageSummary shows rule number and outbound only, joined by comma", () => {
+    const rules: RouteRule[] = [
+      rule({
+        outbound: "wan",
+        list: ["shared"],
+        dest_addr: "10.0.0.0/24",
+      }),
+      rule({
+        outbound: "vpn",
+        list: ["shared"],
+        proto: "udp",
+      }),
+    ]
+    const refs = buildListUsageByRouteRules(rules)
+    const sharedRefs = refs.get("shared") ?? []
+    const summary = formatRoutingListRefsUsageSummary(sharedRefs)
+
+    expect(summary).toContain("#1 → wan")
+    expect(summary).toContain("#2 → vpn")
+    expect(summary).toContain(", ")
+    expect(summary).not.toContain("dest_addr")
+    expect(summary).not.toContain("proto")
+    expect(summary).not.toContain(" • ")
+  })
+
+  test("describeRouteRuleRefForListUsage returns index and outbound", () => {
+    expect(describeRouteRuleRefForListUsage({ ruleIndex: 2, outbound: "x" })).toBe(
+      "#3 → x",
+    )
+  })
+})


### PR DESCRIPTION
Part of splitting #125 into smaller, single-purpose PRs, as you requested in the review.

When a list is selected for a routing or DNS rule, the multi-select now shows a short muted subtitle naming the other rules that already use that list (e.g. `Also in: #2 → vpn, #5 → direct`), so a shared list is not removed by accident.

- `multi-select-list` gains an optional `usageSubtitle` render prop, shown under each dropdown option and each chosen entry.
- `routing-rules-utils` / `dns-rules-utils` gain `buildListUsage*` helpers that map a list name to the sibling rules referencing it, plus concise one-line summary formatters (rule number → outbound/server).
- Hardens `detectInitialLanguage` against a missing `navigator.language` so the helper modules import cleanly in non-browser test environments.
- Unit tests for the usage helpers.

Frontend lint + production build pass.