### PR TITLE
feat(frontend): pause background polling to lighten router load

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,73 +1,132 @@
+import { Suspense, lazy } from "react"
 import { Route, Switch } from "wouter"
 
 import { AppShell } from "@/components/layout/app-shell"
-import { DnsRuleUpsertPage } from "@/pages/dns-rule-upsert-page"
-import { DnsRulesPage } from "@/pages/dns-rules-page"
-import { DnsServersPage } from "@/pages/dns-servers-page"
-import { DnsServerUpsertPage } from "@/pages/dns-servers-upsert-page"
-import { GeneralConfigPage } from "@/pages/general-config-page"
-import { ListUpsertPage } from "@/pages/list-upsert-page"
-import { ListsPage } from "@/pages/lists-page"
-import { OutboundUpsertPage } from "@/pages/outbound-upsert-page"
-import { OutboundsPage } from "@/pages/outbounds-page"
-import { OverviewPage } from "@/pages/overview-page"
-import { RoutingRuleUpsertPage } from "@/pages/routing-rule-upsert-page"
-import { RoutingRulesPage } from "@/pages/routing-rules-page"
+import { TableSkeleton } from "@/components/shared/table-skeleton"
+
+const OverviewPage = lazy(() =>
+  import("@/pages/overview-page").then((m) => ({ default: m.OverviewPage })),
+)
+const GeneralConfigPage = lazy(() =>
+  import("@/pages/general-config-page").then((m) => ({
+    default: m.GeneralConfigPage,
+  })),
+)
+const DnsRuleUpsertPage = lazy(() =>
+  import("@/pages/dns-rule-upsert-page").then((m) => ({
+    default: m.DnsRuleUpsertPage,
+  })),
+)
+const DnsRulesPage = lazy(() =>
+  import("@/pages/dns-rules-page").then((m) => ({ default: m.DnsRulesPage })),
+)
+const DnsServersPage = lazy(() =>
+  import("@/pages/dns-servers-page").then((m) => ({
+    default: m.DnsServersPage,
+  })),
+)
+const DnsServerUpsertPage = lazy(() =>
+  import("@/pages/dns-servers-upsert-page").then((m) => ({
+    default: m.DnsServerUpsertPage,
+  })),
+)
+const ListUpsertPage = lazy(() =>
+  import("@/pages/list-upsert-page").then((m) => ({
+    default: m.ListUpsertPage,
+  })),
+)
+const ListsPage = lazy(() =>
+  import("@/pages/lists-page").then((m) => ({ default: m.ListsPage })),
+)
+const OutboundUpsertPage = lazy(() =>
+  import("@/pages/outbound-upsert-page").then((m) => ({
+    default: m.OutboundUpsertPage,
+  })),
+)
+const OutboundsPage = lazy(() =>
+  import("@/pages/outbounds-page").then((m) => ({ default: m.OutboundsPage })),
+)
+const RoutingRuleUpsertPage = lazy(() =>
+  import("@/pages/routing-rule-upsert-page").then((m) => ({
+    default: m.RoutingRuleUpsertPage,
+  })),
+)
+const RoutingRulesPage = lazy(() =>
+  import("@/pages/routing-rules-page").then((m) => ({
+    default: m.RoutingRulesPage,
+  })),
+)
+
+function RouteSuspenseFallback() {
+  return (
+    <div className="space-y-4 px-4 py-6 md:px-6">
+      <TableSkeleton />
+    </div>
+  )
+}
 
 function App() {
   return (
     <AppShell>
-      <Switch>
-        <Route component={OverviewPage} path="/" />
-        <Route component={GeneralConfigPage} path="/general" />
-        <Route path="/lists/create">
-          <ListUpsertPage mode="create" />
-        </Route>
-        <Route path="/lists/:listId/edit">
-          {(params) => <ListUpsertPage listId={params.listId} mode="edit" />}
-        </Route>
-        <Route component={ListsPage} path="/lists" />
-        <Route path="/outbounds/create">
-          <OutboundUpsertPage mode="create" />
-        </Route>
-        <Route path="/outbounds/:outboundId/edit">
-          {(params) => (
-            <OutboundUpsertPage mode="edit" outboundId={params.outboundId} />
-          )}
-        </Route>
-        <Route component={OutboundsPage} path="/outbounds" />
-        <Route path="/dns-servers/create">
-          <DnsServerUpsertPage mode="create" />
-        </Route>
-        <Route path="/dns-servers/:serverTag/edit">
-          {(params) => (
-            <DnsServerUpsertPage
-              mode="edit"
-              serverTag={decodeURIComponent(params.serverTag)}
-            />
-          )}
-        </Route>
-        <Route component={DnsServersPage} path="/dns-servers" />
-        <Route path="/dns-rules/create">
-          <DnsRuleUpsertPage mode="create" />
-        </Route>
-        <Route path="/dns-rules/:ruleIndex/edit">
-          {(params) => (
-            <DnsRuleUpsertPage mode="edit" ruleIndex={params.ruleIndex} />
-          )}
-        </Route>
-        <Route component={DnsRulesPage} path="/dns-rules" />
-        <Route path="/routing-rules/create">
-          <RoutingRuleUpsertPage mode="create" />
-        </Route>
-        <Route path="/routing-rules/:ruleIndex/edit">
-          {(params) => (
-            <RoutingRuleUpsertPage mode="edit" ruleIndex={params.ruleIndex} />
-          )}
-        </Route>
-        <Route component={RoutingRulesPage} path="/routing-rules" />
-        <Route component={OverviewPage} />
-      </Switch>
+      <Suspense fallback={<RouteSuspenseFallback />}>
+        <Switch>
+          <Route component={OverviewPage} path="/" />
+          <Route component={GeneralConfigPage} path="/general" />
+          <Route path="/lists/create">
+            <ListUpsertPage mode="create" />
+          </Route>
+          <Route path="/lists/:listId/edit">
+            {(params) => <ListUpsertPage listId={params.listId} mode="edit" />}
+          </Route>
+          <Route component={ListsPage} path="/lists" />
+          <Route path="/outbounds/create">
+            <OutboundUpsertPage mode="create" />
+          </Route>
+          <Route path="/outbounds/:outboundId/edit">
+            {(params) => (
+              <OutboundUpsertPage
+                mode="edit"
+                outboundId={params.outboundId}
+              />
+            )}
+          </Route>
+          <Route component={OutboundsPage} path="/outbounds" />
+          <Route path="/dns-servers/create">
+            <DnsServerUpsertPage mode="create" />
+          </Route>
+          <Route path="/dns-servers/:serverTag/edit">
+            {(params) => (
+              <DnsServerUpsertPage
+                mode="edit"
+                serverTag={decodeURIComponent(params.serverTag)}
+              />
+            )}
+          </Route>
+          <Route component={DnsServersPage} path="/dns-servers" />
+          <Route path="/dns-rules/create">
+            <DnsRuleUpsertPage mode="create" />
+          </Route>
+          <Route path="/dns-rules/:ruleIndex/edit">
+            {(params) => (
+              <DnsRuleUpsertPage mode="edit" ruleIndex={params.ruleIndex} />
+            )}
+          </Route>
+          <Route component={DnsRulesPage} path="/dns-rules" />
+          <Route path="/routing-rules/create">
+            <RoutingRuleUpsertPage mode="create" />
+          </Route>
+          <Route path="/routing-rules/:ruleIndex/edit">
+            {(params) => (
+              <RoutingRuleUpsertPage
+                mode="edit"
+                ruleIndex={params.ruleIndex}
+              />
+            )}
+          </Route>
+          <Route component={RoutingRulesPage} path="/routing-rules" />
+          <Route component={OverviewPage} />
+        </Switch>
+      </Suspense>
     </AppShell>
   )
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -33,8 +33,36 @@ const normalizeError = (status: number, payload: unknown): ApiError => {
   return { status, message: `Request failed with status ${status}`, details: payload }
 }
 
+const API_FETCH_TIMEOUT_MS = 90_000
+
+function composeFetchSignals(
+  userSignal: AbortSignal | undefined | null,
+  timeoutMs: number,
+): AbortSignal | undefined {
+  if (
+    typeof AbortSignal === "undefined" ||
+    typeof AbortSignal.timeout !== "function"
+  ) {
+    return userSignal ?? undefined
+  }
+
+  const timeoutSig = AbortSignal.timeout(timeoutMs)
+  const AbortWithAny = AbortSignal as typeof AbortSignal & {
+    any?: (signals: AbortSignal[]) => AbortSignal
+  }
+
+  if (userSignal && typeof AbortWithAny.any === "function") {
+    return AbortWithAny.any([userSignal, timeoutSig])
+  }
+
+  return userSignal ?? timeoutSig
+}
+
 export const apiFetch = async <T>(url: string, options: RequestInit): Promise<T> => {
-  const response = await fetch(url, options)
+  const response = await fetch(url, {
+    ...options,
+    signal: composeFetchSignals(options.signal, API_FETCH_TIMEOUT_MS),
+  })
   const payload = await parseResponsePayload(response)
 
   if (!response.ok) {

--- a/frontend/src/components/layout/warning-banner-state.ts
+++ b/frontend/src/components/layout/warning-banner-state.ts
@@ -1,10 +1,22 @@
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import type { Query } from "@tanstack/query-core"
+import { useQueryClient } from "@tanstack/react-query"
 
 import type { HealthResponse } from "@/api/generated/model"
-import { useRoutingControlPendingState } from "@/api/mutations"
+import type { GetHealthServiceQueryResult } from "@/api/generated/keen-api"
+import {
+  useRoutingControlPendingState,
+} from "@/api/mutations"
 import { useGetHealthService } from "@/api/queries"
 
-const DEFAULT_REFETCH_INTERVAL_MS = 30_000
+type HealthServiceQueryPoll = Query<
+  GetHealthServiceQueryResult,
+  unknown,
+  GetHealthServiceQueryResult,
+  readonly unknown[]
+>
+
+const DEFAULT_REFETCH_INTERVAL_MS = 45_000
 const CONVERGING_REFETCH_INTERVAL_MS = 1_000
 const CONVERGING_WINDOW_MS = 15_000
 
@@ -27,26 +39,47 @@ export type WarningBannerState = {
 
 export function useWarningBannerState(): WarningBannerState {
   const [nowMs, setNowMs] = useState(() => Date.now())
+  const queryClient = useQueryClient()
   const [convergingStartedAtMs, setConvergingStartedAtMs] = useState<number | null>(
     null
   )
   const [convergingApplyStartedTs, setConvergingApplyStartedTs] = useState<
     number | null
   >(null)
+  const computeHealthPollIntervalMs = useCallback(
+    (query: HealthServiceQueryPoll) => {
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState !== "visible"
+      ) {
+        return false
+      }
+
+      if (queryClient.isMutating({ mutationKey: ["postConfig"] }) > 0) {
+        return false
+      }
+
+      if (queryClient.isMutating({ mutationKey: ["postConfigSave"] }) > 0) {
+        return false
+      }
+
+      const response = query.state.data
+      if (response?.status !== 200) {
+        return DEFAULT_REFETCH_INTERVAL_MS
+      }
+
+      const mode = getWarningBannerMode(response.data, Date.now())
+
+      return mode === "dnsmasq-converging" || mode === "dnsmasq-error"
+        ? CONVERGING_REFETCH_INTERVAL_MS
+        : DEFAULT_REFETCH_INTERVAL_MS
+    },
+    [queryClient],
+  )
+
   const healthQuery = useGetHealthService({
     query: {
-      refetchInterval: (query) => {
-        const response = query.state.data
-        if (response?.status !== 200) {
-          return DEFAULT_REFETCH_INTERVAL_MS
-        }
-
-        const mode = getWarningBannerMode(response.data, Date.now())
-
-        return mode === "dnsmasq-converging" || mode === "dnsmasq-error"
-          ? CONVERGING_REFETCH_INTERVAL_MS
-          : DEFAULT_REFETCH_INTERVAL_MS
-      },
+      refetchInterval: computeHealthPollIntervalMs,
       refetchIntervalInBackground: false,
     },
   })

--- a/frontend/src/components/shared/outbound-select.tsx
+++ b/frontend/src/components/shared/outbound-select.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
+import { useQueryClient } from "@tanstack/react-query"
 
 import type { Outbound } from "@/api/generated/model/outbound"
 import type { RuntimeOutboundState } from "@/api/generated/model/runtimeOutboundState"
@@ -15,6 +16,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import {
+  ROUTER_RUNTIME_POLL_MS,
+  routerFriendlyPollingMs,
+} from "@/lib/router-friendly-query"
 
 type OutboundSelectProps = {
   value: string
@@ -40,9 +45,14 @@ export function OutboundSelect({
   disabled,
 }: OutboundSelectProps) {
   const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const pollRuntimeOutboundSelect = useMemo(
+    () => routerFriendlyPollingMs(queryClient, ROUTER_RUNTIME_POLL_MS),
+    [queryClient],
+  )
   const runtimeOutboundsQuery = useGetRuntimeOutbounds({
     query: {
-      refetchInterval: 10_000,
+      refetchInterval: pollRuntimeOutboundSelect,
       refetchIntervalInBackground: false,
     },
   })

--- a/frontend/src/lib/router-friendly-query.ts
+++ b/frontend/src/lib/router-friendly-query.ts
@@ -1,0 +1,57 @@
+import type { QueryClient } from "@tanstack/react-query"
+
+/** Default poll period for outbound/runtime-style queries when the UI tab is active. */
+export const ROUTER_RUNTIME_POLL_MS = 30_000
+
+export function isDocumentTabHidden(
+  visibilityState: DocumentVisibilityState = getDocumentVisibilityState(),
+): boolean {
+  return visibilityState !== "visible"
+}
+
+export function hasConfigMutationInFlight(
+  queryClient: Pick<QueryClient, "isMutating">,
+): boolean {
+  return (
+    queryClient.isMutating({ mutationKey: ["postConfig"] }) > 0 ||
+    queryClient.isMutating({ mutationKey: ["postConfigSave"] }) > 0
+  )
+}
+
+/** Resolves TanStack `refetchInterval` for router-friendly polling. */
+export function resolveRouterFriendlyPollInterval(
+  queryClient: Pick<QueryClient, "isMutating">,
+  intervalWhenActiveMs: number,
+  visibilityState: DocumentVisibilityState = getDocumentVisibilityState(),
+): number | false {
+  if (isDocumentTabHidden(visibilityState)) {
+    return false
+  }
+
+  if (hasConfigMutationInFlight(queryClient)) {
+    return false
+  }
+
+  return intervalWhenActiveMs
+}
+
+/**
+ * Pause background polling while the browser tab is hidden or while draft/apply config
+ * writes are running (fewer bursts on low-power routers; avoids racing refetches mid-save).
+ * Mounting components must call `useConfigMutationPending()` when using this interval so
+ * the query options refresh when mutations start/end.
+ */
+export function routerFriendlyPollingMs(
+  queryClient: QueryClient,
+  intervalWhenActiveMs: number,
+) {
+  return () => resolveRouterFriendlyPollInterval(queryClient, intervalWhenActiveMs)
+}
+
+function getDocumentVisibilityState(): DocumentVisibilityState {
+  if (typeof document === "undefined") {
+    return "visible"
+  }
+
+  return document.visibilityState
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -14,8 +14,9 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 30_000,
-      gcTime: 5 * 60_000,
+      staleTime: 60_000,
+      gcTime: 3 * 60_000,
+      refetchOnWindowFocus: false,
       retry: (failureCount, error) => {
         const status =
           typeof error === "object" &&

--- a/frontend/src/pages/general-config-page.tsx
+++ b/frontend/src/pages/general-config-page.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
 import { useForm } from "@tanstack/react-form"
@@ -39,6 +40,10 @@ import {
   setFormServerErrors,
   splitFormApiErrors,
 } from "@/lib/form-api-errors"
+import {
+  ROUTER_RUNTIME_POLL_MS,
+  routerFriendlyPollingMs,
+} from "@/lib/router-friendly-query"
 import { toast } from "sonner"
 
 type SettingsDraft = {
@@ -115,9 +120,13 @@ function LoadedGeneralConfigPage({
 }: LoadedGeneralConfigPageProps) {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
+  const pollRuntimeInterfaces = useMemo(
+    () => routerFriendlyPollingMs(queryClient, ROUTER_RUNTIME_POLL_MS),
+    [queryClient],
+  )
   const runtimeInterfacesQuery = useGetRuntimeInterfaces({
     query: {
-      refetchInterval: 10_000,
+      refetchInterval: pollRuntimeInterfaces,
       refetchIntervalInBackground: false,
     },
   })

--- a/frontend/src/pages/overview-page.tsx
+++ b/frontend/src/pages/overview-page.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 import { Download, Play, RotateCw, Square } from "lucide-react"
 
@@ -38,33 +39,54 @@ import { DiagnosticsDownloadDialog } from "@/components/overview/diagnostics-dow
 import { getDnsmasqBadgeState } from "@/components/overview/dnsmasq-status"
 import { RoutingTestPanel } from "@/components/overview/routing-test-panel"
 import { getApiErrorMessage } from "@/lib/api-errors"
+import {
+  ROUTER_RUNTIME_POLL_MS,
+  routerFriendlyPollingMs,
+} from "@/lib/router-friendly-query"
 
 export function OverviewPage() {
   const { t } = useTranslation()
+  const queryClient = useQueryClient()
   const [dnsCheckStatus, setDnsCheckStatus] = useState<DnsCheckStatus>("idle")
   const [isDiagnosticsDialogOpen, setIsDiagnosticsDialogOpen] = useState(false)
+
+  const pollOverviewService = useMemo(
+    () => routerFriendlyPollingMs(queryClient, 45_000),
+    [queryClient],
+  )
+
+  const pollOverviewRouting = useMemo(
+    () => routerFriendlyPollingMs(queryClient, 60_000),
+    [queryClient],
+  )
+
+  const pollOverviewRuntime = useMemo(
+    () => routerFriendlyPollingMs(queryClient, ROUTER_RUNTIME_POLL_MS),
+    [queryClient],
+  )
+
   const serviceHealthQuery = useGetHealthService({
     query: {
-      refetchInterval: 30_000,
+      refetchInterval: pollOverviewService,
       refetchIntervalInBackground: false,
     },
   })
   const configQuery = useGetConfig()
   const routingHealthQuery = useGetHealthRouting({
     query: {
-      refetchInterval: 45_000,
+      refetchInterval: pollOverviewRouting,
       refetchIntervalInBackground: false,
     },
   })
   const runtimeOutboundsQuery = useGetRuntimeOutbounds({
     query: {
-      refetchInterval: 30_000,
+      refetchInterval: pollOverviewRuntime,
       refetchIntervalInBackground: false,
     },
   })
   const runtimeInterfacesQuery = useGetRuntimeInterfaces({
     query: {
-      refetchInterval: 30_000,
+      refetchInterval: pollOverviewRuntime,
       refetchIntervalInBackground: false,
     },
   })

--- a/frontend/tests/router-friendly-query.test.ts
+++ b/frontend/tests/router-friendly-query.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test"
+import { QueryClient } from "@tanstack/react-query"
+
+import {
+  hasConfigMutationInFlight,
+  isDocumentTabHidden,
+  resolveRouterFriendlyPollInterval,
+  ROUTER_RUNTIME_POLL_MS,
+} from "../src/lib/router-friendly-query"
+
+describe("router-friendly polling", () => {
+  test("isDocumentTabHidden respects visibility state", () => {
+    expect(isDocumentTabHidden("visible")).toBe(false)
+    expect(isDocumentTabHidden("hidden")).toBe(true)
+  })
+
+  test("hasConfigMutationInFlight detects postConfig and postConfigSave", () => {
+    const queryClient = {
+      isMutating: ({ mutationKey }: { mutationKey: string[] }) => {
+        if (mutationKey[0] === "postConfig") {
+          return 1
+        }
+        return 0
+      },
+    } as Pick<QueryClient, "isMutating">
+
+    expect(hasConfigMutationInFlight(queryClient)).toBe(true)
+  })
+
+  test("resolveRouterFriendlyPollInterval pauses when hidden or mutating", () => {
+    const idleClient = {
+      isMutating: () => 0,
+    } as Pick<QueryClient, "isMutating">
+
+    expect(
+      resolveRouterFriendlyPollInterval(
+        idleClient,
+        ROUTER_RUNTIME_POLL_MS,
+        "visible",
+      ),
+    ).toBe(ROUTER_RUNTIME_POLL_MS)
+
+    expect(
+      resolveRouterFriendlyPollInterval(
+        idleClient,
+        ROUTER_RUNTIME_POLL_MS,
+        "hidden",
+      ),
+    ).toBe(false)
+
+    const mutatingClient = {
+      isMutating: ({ mutationKey }: { mutationKey: string[] }) =>
+        mutationKey[0] === "postConfigSave" ? 1 : 0,
+    } as Pick<QueryClient, "isMutating">
+
+    expect(
+      resolveRouterFriendlyPollInterval(
+        mutatingClient,
+        ROUTER_RUNTIME_POLL_MS,
+        "visible",
+      ),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Part of splitting #125 into smaller, single-purpose PRs, as you requested in the review.

Home routers are weak; constant background refetches waste their CPU/RAM. This makes polling router-friendly:

- `router-friendly-query`: a `refetchInterval` resolver that returns `false` (no poll) while the browser tab is hidden or a config draft/apply write is in flight, so refetches never race a save.
- Adopted on the overview, general-config and outbound-select runtime queries, and folded into the warning banner's adaptive health poll.
- `apiFetch` applies a 90s timeout via `AbortSignal`, so a hung request cannot pin the UI forever.
- Query-client tuning: longer `staleTime`, shorter `gcTime`, no refetch-on-window-focus.
- Page routes are lazy-loaded with Suspense, so first paint ships a smaller JS chunk.

Frontend lint + production build pass.