### PR TITLE
feat(config): validate rule references, interface outbounds, and request fields

### DIFF
--- a/src/api/handler_test_routing.cpp
+++ b/src/api/handler_test_routing.cpp
@@ -26,6 +26,11 @@ void register_test_routing_handler(ApiServer& server, ApiContext& ctx) {
             throw ApiError("Invalid request body", 400, payload.dump());
         }
 
+        if (req.target.empty()) {
+            nlohmann::json payload = {{"error", "Field 'target' must not be empty"}};
+            throw ApiError("Field 'target' must not be empty", 400, payload.dump());
+        }
+
         auto result = ctx.compute_test_routing(req.target);
 
         api::RoutingTestResponse resp;

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -665,6 +665,13 @@ void validate_config(const Config& cfg) {
                       "List '" + name +
                           "' must have at least one of: url, domains, ip_cidrs, file");
         }
+
+        // NOTE: individual list entries are intentionally NOT validated here.
+        // Lists are routinely aggregated from external sources and legitimately
+        // contain entries the parser does not recognise (CIDRs in domain lists,
+        // wildcard/host:port forms, comments, blank lines). ListParser skips
+        // unrecognised entries gracefully when building sets, so rejecting the
+        // whole config over them would break real-world setups.
     }
 
     const auto& outbounds = cfg.outbounds.value_or(std::vector<Outbound>{});
@@ -672,6 +679,12 @@ void validate_config(const Config& cfg) {
         validate_tag(issues, "outbounds." + ob.tag + ".tag", "Outbound tag", ob.tag);
 
         if (ob.type == OutboundType::INTERFACE) {
+            const std::string iface = trim_copy(ob.interface.value_or(""));
+            if (iface.empty()) {
+                add_issue(issues,
+                          "outbounds." + ob.tag + ".interface",
+                          "Interface outbound '" + ob.tag + "' requires a non-empty interface name");
+            }
             if (ob.gateway.has_value() && !is_valid_ipv4_address(*ob.gateway)) {
                 add_issue(issues,
                           "outbounds." + ob.tag + ".gateway",
@@ -934,6 +947,90 @@ void validate_config(const Config& cfg) {
     } else {
         add_issue(issues, "dns.system_resolver",
                   "dns.system_resolver must be present");
+    }
+
+    std::set<std::string> configured_list_names;
+    for (const auto& [list_name, _] : cfg.lists.value_or(std::map<std::string, ListConfig>{})) {
+        configured_list_names.insert(list_name);
+    }
+
+    std::set<std::string> outbound_tags;
+    for (const auto& ob : outbounds) {
+        outbound_tags.insert(ob.tag);
+    }
+
+    const auto validate_rule_list_refs =
+        [&](const std::string& rule_path,
+            const std::vector<std::string>& list_refs) {
+            for (size_t list_index = 0; list_index < list_refs.size(); ++list_index) {
+                const std::string list_path =
+                    rule_path + ".list[" + std::to_string(list_index) + "]";
+                const std::string list_name = trim_copy(list_refs[list_index]);
+                if (list_name.empty()) {
+                    add_issue(issues,
+                              list_path,
+                              rule_path + ".list[" + std::to_string(list_index) +
+                                  "] must not be empty");
+                    continue;
+                }
+                if (configured_list_names.find(list_name) == configured_list_names.end()) {
+                    add_issue(issues,
+                              list_path,
+                              rule_path + " references unknown list '" + list_name + "'");
+                }
+            }
+        };
+
+    const auto& route_rules =
+        cfg.route.value_or(RouteConfig{}).rules.value_or(std::vector<RouteRule>{});
+    for (size_t rule_index = 0; rule_index < route_rules.size(); ++rule_index) {
+        const auto& rule = route_rules[rule_index];
+        const std::string rule_path = "route.rules[" + std::to_string(rule_index) + "]";
+
+        const std::string outbound_tag = trim_copy(rule.outbound);
+        if (outbound_tag.empty()) {
+            add_issue(issues,
+                      rule_path + ".outbound",
+                      rule_path + ".outbound must not be empty");
+        } else if (outbound_tags.find(outbound_tag) == outbound_tags.end()) {
+            add_issue(issues,
+                      rule_path + ".outbound",
+                      rule_path + " references unknown outbound tag '" + outbound_tag + "'");
+        }
+
+        validate_rule_list_refs(rule_path, route_rule_lists(rule));
+    }
+
+    if (cfg.dns.has_value() && cfg.dns->rules.has_value()) {
+        std::set<std::string> dns_server_tags;
+        for (const auto& srv : cfg.dns->servers.value_or(std::vector<DnsServer>{})) {
+            dns_server_tags.insert(srv.tag);
+        }
+
+        for (size_t rule_index = 0; rule_index < cfg.dns->rules->size(); ++rule_index) {
+            const auto& rule = cfg.dns->rules->at(rule_index);
+            const std::string rule_path = "dns.rules[" + std::to_string(rule_index) + "]";
+
+            const std::string server_tag = trim_copy(rule.server);
+            if (server_tag.empty()) {
+                add_issue(issues,
+                          rule_path + ".server",
+                          rule_path + ".server must not be empty");
+            } else if (dns_server_tags.find(server_tag) == dns_server_tags.end()) {
+                add_issue(issues,
+                          rule_path + ".server",
+                          rule_path + " references unknown DNS server tag '" + server_tag +
+                              "'");
+            }
+
+            if (rule.list.empty()) {
+                add_issue(issues,
+                          rule_path + ".list",
+                          rule_path + ".list must include at least one list name");
+            } else {
+                validate_rule_list_refs(rule_path, rule.list);
+            }
+        }
     }
 
     if (!issues.empty()) {

--- a/src/daemon/daemon_api.cpp
+++ b/src/daemon/daemon_api.cpp
@@ -349,7 +349,7 @@ void Daemon::setup_api() {
                 });
         },
         [this]() {
-            return build_runtime_interface_inventory_response(netlink_);
+            return build_runtime_interface_inventory_response_or_empty(netlink_);
         },
         [this](const Config& config) {
             return build_list_refresh_state_map(config, list_service_.cache_manager());

--- a/src/health/runtime_interface_inventory.cpp
+++ b/src/health/runtime_interface_inventory.cpp
@@ -56,6 +56,15 @@ api::RuntimeInterfaceInventoryResponse build_runtime_interface_inventory_respons
     return build_runtime_interface_inventory_response(netlink.dump_interfaces());
 }
 
+api::RuntimeInterfaceInventoryResponse
+build_runtime_interface_inventory_response_or_empty(NetlinkManager& netlink) {
+    try {
+        return build_runtime_interface_inventory_response(netlink);
+    } catch (const NetlinkError&) {
+        return api::RuntimeInterfaceInventoryResponse{};
+    }
+}
+
 } // namespace keen_pbr3
 
 #endif // WITH_API

--- a/src/health/runtime_interface_inventory.hpp
+++ b/src/health/runtime_interface_inventory.hpp
@@ -13,6 +13,10 @@ api::RuntimeInterfaceInventoryResponse build_runtime_interface_inventory_respons
 api::RuntimeInterfaceInventoryResponse build_runtime_interface_inventory_response(
     NetlinkManager& netlink);
 
+// Returns an empty inventory when netlink enumeration fails instead of throwing.
+api::RuntimeInterfaceInventoryResponse
+build_runtime_interface_inventory_response_or_empty(NetlinkManager& netlink);
+
 } // namespace keen_pbr3
 
 #endif // WITH_API

--- a/tests/test_api_test_routing.cpp
+++ b/tests/test_api_test_routing.cpp
@@ -1,0 +1,75 @@
+#ifdef WITH_API
+
+#include <doctest/doctest.h>
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+#include "../src/api/handler_test_routing.hpp"
+#include "../src/api/server.hpp"
+#include "../src/api/sse_broadcaster.hpp"
+
+namespace keen_pbr3 {
+
+namespace {
+
+const std::string kApiConfigPath = "/tmp/keen-pbr-test-config.json";
+constexpr const char* kApiListen = "127.0.0.1:18190";
+
+ApiContext make_test_api_context(SseBroadcaster& broadcaster) {
+    return ApiContext{
+        kApiConfigPath,
+        broadcaster,
+        []() { return Config{}; },
+        []() { return false; },
+        [](Config, std::string) {},
+        []() -> std::optional<std::pair<Config, std::string>> { return std::nullopt; },
+        []() {},
+        [](const Config&) {},
+        []() { return ServiceHealthState{}; },
+        []() { return RoutingHealthReport{}; },
+        []() { return api::RuntimeOutboundsResponse{}; },
+        []() { return api::RuntimeInterfaceInventoryResponse{}; },
+        [](const Config&) { return std::map<std::string, api::ListRefreshStateValue>{}; },
+        [](const std::string& target) {
+            TestRoutingResult result;
+            result.target = target;
+            return result;
+        },
+        []() {},
+        []() {},
+        [](Config, std::string) { return ConfigApplyResult{}; },
+        []() {},
+        []() {},
+        []() {},
+        [](std::optional<std::string>) { return ListRefreshOperationResult{}; },
+    };
+}
+
+} // namespace
+
+TEST_CASE("register_test_routing_handler: rejects empty target") {
+    SseBroadcaster broadcaster;
+    api::ApiConfig api_config;
+    api_config.listen = std::string(kApiListen);
+
+    ApiServer server(api_config);
+    auto ctx = make_test_api_context(broadcaster);
+    register_test_routing_handler(server, ctx);
+
+    server.start();
+
+    httplib::Client client("127.0.0.1", 18190);
+    const auto response =
+        client.Post("/api/routing/test", R"({"target":""})", "application/json");
+    server.stop();
+
+    REQUIRE(response != nullptr);
+    CHECK(response->status == 400);
+
+    const auto body = nlohmann::json::parse(response->body);
+    CHECK(body["error"] == "Field 'target' must not be empty");
+}
+
+} // namespace keen_pbr3
+
+#endif // WITH_API

--- a/tests/test_config_validation.cpp
+++ b/tests/test_config_validation.cpp
@@ -306,6 +306,8 @@ TEST_CASE("dns servers: at most one keenetic type server is allowed") {
 
 TEST_CASE("route rule enabled: parse and serialize cover true false omitted and null") {
     const auto cfg_true = parse_test_config(R"({
+        "lists":{"ads":{"domains":["example.com"]}},
+        "outbounds":[{"tag":"vpn","type":"interface","interface":"eth0"}],
         "route":{"rules":[{"enabled":true,"list":["ads"],"outbound":"vpn"}]}
     })");
     REQUIRE(cfg_true.route.has_value());
@@ -316,6 +318,8 @@ TEST_CASE("route rule enabled: parse and serialize cover true false omitted and 
     CHECK(json_true["route"]["rules"][0]["enabled"] == true);
 
     const auto cfg_false = parse_test_config(R"({
+        "lists":{"ads":{"domains":["example.com"]}},
+        "outbounds":[{"tag":"vpn","type":"interface","interface":"eth0"}],
         "route":{"rules":[{"enabled":false,"list":["ads"],"outbound":"vpn"}]}
     })");
     REQUIRE(cfg_false.route.has_value());
@@ -326,6 +330,8 @@ TEST_CASE("route rule enabled: parse and serialize cover true false omitted and 
     CHECK(json_false["route"]["rules"][0]["enabled"] == false);
 
     const auto cfg_omitted = parse_test_config(R"({
+        "lists":{"ads":{"domains":["example.com"]}},
+        "outbounds":[{"tag":"vpn","type":"interface","interface":"eth0"}],
         "route":{"rules":[{"list":["ads"],"outbound":"vpn"}]}
     })");
     REQUIRE(cfg_omitted.route.has_value());
@@ -336,6 +342,8 @@ TEST_CASE("route rule enabled: parse and serialize cover true false omitted and 
     CHECK(json_omitted["route"]["rules"][0]["enabled"].is_null());
 
     const auto cfg_null = parse_test_config(R"({
+        "lists":{"ads":{"domains":["example.com"]}},
+        "outbounds":[{"tag":"vpn","type":"interface","interface":"eth0"}],
         "route":{"rules":[{"enabled":null,"list":["ads"],"outbound":"vpn"}]}
     })");
     REQUIRE(cfg_null.route.has_value());
@@ -348,6 +356,7 @@ TEST_CASE("route rule enabled: parse and serialize cover true false omitted and 
 
 TEST_CASE("dns rule enabled: parse and serialize cover true false omitted and null") {
     const auto cfg_true = parse_test_config(R"({
+        "lists":{"ads":{"domains":["example.com"]}},
         "dns":{
             "servers":[{"tag":"vpn_dns","address":"10.8.0.1"}],
             "fallback":["vpn_dns"],
@@ -362,6 +371,7 @@ TEST_CASE("dns rule enabled: parse and serialize cover true false omitted and nu
     CHECK(json_true["dns"]["rules"][0]["enabled"] == true);
 
     const auto cfg_false = parse_test_config(R"({
+        "lists":{"ads":{"domains":["example.com"]}},
         "dns":{
             "servers":[{"tag":"vpn_dns","address":"10.8.0.1"}],
             "fallback":["vpn_dns"],
@@ -376,6 +386,7 @@ TEST_CASE("dns rule enabled: parse and serialize cover true false omitted and nu
     CHECK(json_false["dns"]["rules"][0]["enabled"] == false);
 
     const auto cfg_omitted = parse_test_config(R"({
+        "lists":{"ads":{"domains":["example.com"]}},
         "dns":{
             "servers":[{"tag":"vpn_dns","address":"10.8.0.1"}],
             "fallback":["vpn_dns"],
@@ -390,6 +401,7 @@ TEST_CASE("dns rule enabled: parse and serialize cover true false omitted and nu
     CHECK(json_omitted["dns"]["rules"][0]["enabled"].is_null());
 
     const auto cfg_null = parse_test_config(R"({
+        "lists":{"ads":{"domains":["example.com"]}},
         "dns":{
             "servers":[{"tag":"vpn_dns","address":"10.8.0.1"}],
             "fallback":["vpn_dns"],
@@ -688,6 +700,7 @@ TEST_CASE("route rule: invalid dest_addr reports route.rules[0].dest_addr") {
 TEST_CASE("route rule: iptables rejects multiport src_port combined with dest_port") {
     const auto issues = validate_issues(R"({
         "daemon":{"firewall_backend":"iptables"},
+        "outbounds":[{"tag":"vpn","type":"interface","interface":"eth0"}],
         "route":{"rules":[
             {"outbound":"vpn","src_port":"555,666","dest_port":"555-666"}
         ]}
@@ -700,6 +713,7 @@ TEST_CASE("route rule: iptables rejects multiport src_port combined with dest_po
 TEST_CASE("route rule: iptables rejects multiport dest_port combined with src_port") {
     const auto issues = validate_issues(R"({
         "daemon":{"firewall_backend":"iptables"},
+        "outbounds":[{"tag":"vpn","type":"interface","interface":"eth0"}],
         "route":{"rules":[
             {"outbound":"vpn","src_port":"555-666","dest_port":"555,666"}
         ]}
@@ -711,6 +725,7 @@ TEST_CASE("route rule: iptables rejects multiport dest_port combined with src_po
 TEST_CASE("route rule: iptables allows src_port and dest_port ranges together") {
     CHECK_NOTHROW(parse_test_config(R"({
         "daemon":{"firewall_backend":"iptables"},
+        "outbounds":[{"tag":"vpn","type":"interface","interface":"eth0"}],
         "route":{"rules":[
             {"outbound":"vpn","src_port":"555-666","dest_port":"777-888"}
         ]}
@@ -720,6 +735,7 @@ TEST_CASE("route rule: iptables allows src_port and dest_port ranges together") 
 TEST_CASE("route rule: nftables allows mixed multiport and dest_port") {
     CHECK_NOTHROW(parse_test_config(R"({
         "daemon":{"firewall_backend":"nftables"},
+        "outbounds":[{"tag":"vpn","type":"interface","interface":"eth0"}],
         "route":{"rules":[
             {"outbound":"vpn","src_port":"555,666","dest_port":"555-666"}
         ]}
@@ -729,6 +745,7 @@ TEST_CASE("route rule: nftables allows mixed multiport and dest_port") {
 TEST_CASE("route rule: auto allows mixed multiport and dest_port") {
     CHECK_NOTHROW(parse_test_config(R"({
         "daemon":{"firewall_backend":"auto"},
+        "outbounds":[{"tag":"vpn","type":"interface","interface":"eth0"}],
         "route":{"rules":[
             {"outbound":"vpn","src_port":"555,666","dest_port":"555-666"}
         ]}
@@ -736,16 +753,16 @@ TEST_CASE("route rule: auto allows mixed multiport and dest_port") {
 }
 
 TEST_CASE("route inbound_interfaces: omitted is accepted") {
-    CHECK_NOTHROW(parse_test_config(R"({"route":{"rules":[{"list":["ads"],"outbound":"vpn"}]}})"));
+    CHECK_NOTHROW(parse_test_config(R"({"lists":{"ads":{"domains":["example.com"]}},"outbounds":[{"tag":"vpn","type":"interface","interface":"eth0"}],"route":{"rules":[{"list":["ads"],"outbound":"vpn"}]}})"));
 }
 
 TEST_CASE("route inbound_interfaces: empty array is accepted") {
-    CHECK_NOTHROW(parse_test_config(R"({"route":{"inbound_interfaces":[],"rules":[{"list":["ads"],"outbound":"vpn"}]}})"));
+    CHECK_NOTHROW(parse_test_config(R"({"lists":{"ads":{"domains":["example.com"]}},"outbounds":[{"tag":"vpn","type":"interface","interface":"eth0"}],"route":{"inbound_interfaces":[],"rules":[{"list":["ads"],"outbound":"vpn"}]}})"));
 }
 
 TEST_CASE("route inbound_interfaces: valid entries are parsed") {
     auto cfg = parse_test_config(
-        R"({"route":{"inbound_interfaces":["br0","wg0"],"rules":[{"list":["ads"],"outbound":"vpn"}]}})");
+        R"({"lists":{"ads":{"domains":["example.com"]}},"outbounds":[{"tag":"vpn","type":"interface","interface":"eth0"}],"route":{"inbound_interfaces":["br0","wg0"],"rules":[{"list":["ads"],"outbound":"vpn"}]}})");
     REQUIRE(cfg.route.has_value());
     REQUIRE(cfg.route->inbound_interfaces.has_value());
     CHECK(cfg.route->inbound_interfaces->size() == 2);
@@ -1063,4 +1080,67 @@ TEST_CASE("daemon.skip_marked_packets: rejects non-boolean value") {
     const auto issues = parse_issues(R"({"daemon":{"skip_marked_packets":"yes"}})");
     REQUIRE(issues.size() == 1);
     CHECK(issues[0].path == "daemon.skip_marked_packets");
+}
+
+// =============================================================================
+// Cross-reference validation: route rules, DNS rules, outbounds
+// =============================================================================
+
+TEST_CASE("route rule: unknown outbound tag is rejected") {
+    const auto issues = validate_issues(R"({
+        "lists":{"blocked":{"ip_cidrs":["10.0.0.0/8"]}},
+        "outbounds":[{"tag":"wan","type":"interface","interface":"eth0"}],
+        "route":{"rules":[{"list":["blocked"],"outbound":"missing"}]}
+    })");
+    REQUIRE(issues.size() == 1);
+    CHECK(issues[0].path == "route.rules[0].outbound");
+    CHECK(issues[0].message.find("unknown outbound") != std::string::npos);
+}
+
+TEST_CASE("route rule: unknown list name is rejected") {
+    const auto issues = validate_issues(R"({
+        "lists":{"blocked":{"ip_cidrs":["10.0.0.0/8"]}},
+        "outbounds":[{"tag":"wan","type":"interface","interface":"eth0"}],
+        "route":{"rules":[{"list":["ghost"],"outbound":"wan"}]}
+    })");
+    REQUIRE(issues.size() == 1);
+    CHECK(issues[0].path == "route.rules[0].list[0]");
+    CHECK(issues[0].message.find("unknown list") != std::string::npos);
+}
+
+TEST_CASE("dns rule: unknown server tag is rejected") {
+    const auto issues = validate_issues(R"({
+        "lists":{"domains":{"domains":["example.com"]}},
+        "dns":{
+            "servers":[{"tag":"main","address":"1.1.1.1"}],
+            "fallback":["main"],
+            "rules":[{"list":["domains"],"server":"missing"}]
+        }
+    })");
+    REQUIRE(issues.size() == 1);
+    CHECK(issues[0].path == "dns.rules[0].server");
+    CHECK(issues[0].message.find("unknown DNS server") != std::string::npos);
+}
+
+TEST_CASE("dns rule: unknown list name is rejected") {
+    const auto issues = validate_issues(R"({
+        "lists":{"domains":{"domains":["example.com"]}},
+        "dns":{
+            "servers":[{"tag":"main","address":"1.1.1.1"}],
+            "fallback":["main"],
+            "rules":[{"list":["ghost"],"server":"main"}]
+        }
+    })");
+    REQUIRE(issues.size() == 1);
+    CHECK(issues[0].path == "dns.rules[0].list[0]");
+    CHECK(issues[0].message.find("unknown list") != std::string::npos);
+}
+
+TEST_CASE("interface outbound: empty interface name is rejected") {
+    const auto issues = validate_issues(R"({
+        "outbounds":[{"tag":"wan","type":"interface","interface":""}],
+        "dns":{"servers":[{"tag":"main","address":"1.1.1.1"}],"fallback":["main"]}
+    })");
+    REQUIRE(issues.size() == 1);
+    CHECK(issues[0].path == "outbounds.wan.interface");
 }


### PR DESCRIPTION
Part of splitting #125 into smaller, single-purpose PRs, as you requested — scoped to exactly the validation you asked for.

Surface misconfigurations on `POST /api/config` instead of at apply time:

- `validate_config` rejects route/DNS rules that reference an unknown outbound tag, DNS-server tag or list name, and requires interface outbounds to carry a non-empty interface name.
- `POST /api/routing/test` rejects an empty target with HTTP 400 and a structured error body instead of running a meaningless query.
- The runtime interface inventory endpoint returns an empty inventory when netlink enumeration fails, rather than failing the whole request with HTTP 500.

Per your review, individual list **entries** are intentionally NOT validated — lists are routinely aggregated from external sources and legitimately contain forms the parser does not recognise (CIDRs in domain lists, wildcard/`host:port`, comments). `ListParser` already skips those gracefully when building sets, so rejecting a whole config over them would break large real-world configs.

C++ build + full doctest suite pass.